### PR TITLE
fix(server): return all challenges if not started for admins

### DIFF
--- a/packages/server/src/api/challs/get.ts
+++ b/packages/server/src/api/challs/get.ts
@@ -3,9 +3,10 @@ import { makeFastifyRoute } from '../helpers'
 import config from '../../config/server'
 import { getCleanedChallenges } from '../../challenges'
 import { getChallengeInfo } from '../../cache/leaderboard'
+import Permissions from '../../util/perms'
 
-export default makeFastifyRoute(challsGet, async ({ res }) => {
-  if (Date.now() < config.startTime) {
+export default makeFastifyRoute(challsGet, async ({ res, user }) => {
+  if (Date.now() < config.startTime && !(user.perms & Permissions.challsRead)) {
     return res.badNotStarted()
   }
 

--- a/packages/server/test/_util.ts
+++ b/packages/server/test/_util.ts
@@ -4,21 +4,23 @@ import * as db from '../src/database'
 import { Challenge } from '../src/challenges/types'
 
 // Generate only valid parameters
-export const generateTestUser = (): Omit<db.users.User, 'id'> => ({
+export const generateTestUser = (perms = 0): Omit<db.users.User, 'id'> => ({
   email: uuidv4() + '@test.com',
   name: uuidv4(),
   division: Object.keys(config.divisions)[0],
-  perms: 0,
+  perms: perms,
 })
 
 // Generate a real user, adding to database
-export const generateRealTestUser = async (): Promise<{
+export const generateRealTestUser = async (
+  perms = 0
+): Promise<{
   user: db.users.User
   cleanup: () => Promise<void>
 }> => {
   const id = uuidv4()
 
-  const userData = generateTestUser()
+  const userData = generateTestUser(perms)
   const user = await db.users.makeUser({
     ...userData,
     id,


### PR DESCRIPTION
Return `badNotStarted` only for non-admins in `/api/v1/challs`

closes #48 