### PR TITLE
fix(ci): build docker image only main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'otter-sec/rctf'
     needs:
       - shellcheck
       - lint


### PR DESCRIPTION
It doesn't make much sense right now to build images for non-main branches. at a later point when we have a staging branch we might consider building a different image though.

closes #55 