### PR TITLE
feat(api): add admin user filters

### DIFF
--- a/apps/api/src/routes/v2/admin/routes/get-admin-users.ts
+++ b/apps/api/src/routes/v2/admin/routes/get-admin-users.ts
@@ -1,12 +1,92 @@
-import { GetAdminUsersRouteV2 } from '@rctf/types'
+import { config } from '@rctf/config'
+import type { AdminTeamStatus, ResponseHelpers } from '@rctf/types'
+import {
+  AdminTeamStatus as AdminTeamStatusValue,
+  BadBody,
+  GetAdminUsersRouteV2,
+} from '@rctf/types'
 import { getAllUsersWithScores } from '../../../../services/users'
 import adminGroup from '../group'
 
-adminGroup.route(
-  GetAdminUsersRouteV2,
-  async ({ ctx, res, query: { limit, offset, search } }) => {
-    return res.goodAdminUsers(
-      await getAllUsersWithScores(ctx.var.db, limit, offset, search)
-    )
+type AdminUsersResponseHelpers = ResponseHelpers<[typeof BadBody]>
+
+const adminTeamStatuses = Object.values(
+  AdminTeamStatusValue
+) as AdminTeamStatus[]
+
+const splitQueryList = (value: string | undefined): string[] =>
+  value
+    ?.split(',')
+    .map(item => item.trim())
+    .filter(Boolean) ?? []
+
+const parseEnumList = <TValue extends string>(
+  value: string | undefined,
+  validValues: readonly TValue[]
+): TValue[] | undefined => {
+  const items = splitQueryList(value)
+  const values = new Set<string>(validValues)
+
+  if (!items.every(item => values.has(item))) {
+    return undefined
   }
-)
+
+  return items as TValue[]
+}
+
+const parseDivisionList = (value: string | undefined): string[] | undefined => {
+  const items = splitQueryList(value)
+  if (!items.every(division => Object.hasOwn(config.divisions, division))) {
+    return undefined
+  }
+
+  return items
+}
+
+const badQueryList = (
+  res: AdminUsersResponseHelpers,
+  key: string,
+  label: string
+) =>
+  res.badBody({
+    reason: `query:${key}: invalid ${label}`,
+  })
+
+adminGroup.route(GetAdminUsersRouteV2, async ({ ctx, res, query }) => {
+  const statuses = parseEnumList(query.statuses, adminTeamStatuses)
+  if (query.statuses !== undefined && !statuses) {
+    return badQueryList(res, 'statuses', 'status')
+  }
+
+  const excludeStatuses = parseEnumList(
+    query.excludeStatuses,
+    adminTeamStatuses
+  )
+  if (query.excludeStatuses !== undefined && !excludeStatuses) {
+    return badQueryList(res, 'excludeStatuses', 'status')
+  }
+
+  const divisions = parseDivisionList(query.divisions)
+  if (query.divisions !== undefined && !divisions) {
+    return badQueryList(res, 'divisions', 'division')
+  }
+
+  const excludeDivisions = parseDivisionList(query.excludeDivisions)
+  if (query.excludeDivisions !== undefined && !excludeDivisions) {
+    return badQueryList(res, 'excludeDivisions', 'division')
+  }
+
+  return res.goodAdminUsers(
+    await getAllUsersWithScores(ctx.var.db, {
+      limit: query.limit,
+      offset: query.offset,
+      search: query.search,
+      sortBy: query.sortBy,
+      sortOrder: query.sortOrder,
+      statuses,
+      excludeStatuses,
+      divisions,
+      excludeDivisions,
+    })
+  )
+})

--- a/apps/api/src/services/users.ts
+++ b/apps/api/src/services/users.ts
@@ -2,6 +2,9 @@ import type { DatabaseClient, User } from '@rctf/db'
 import { challenges, solves, users } from '@rctf/db'
 import { getErrorConstraint, takeUnique } from '@rctf/db/util'
 import type {
+  AdminTeamSortBy,
+  AdminTeamSortOrder,
+  AdminTeamStatus,
   BadEmailNoExists,
   BadUnknownUser,
   BadZeroAuth,
@@ -12,12 +15,26 @@ import type {
   ResponseHelpers,
 } from '@rctf/types'
 import {
+  AdminTeamSortBy as AdminTeamSortByValue,
+  AdminTeamSortOrder as AdminTeamSortOrderValue,
+  AdminTeamStatus as AdminTeamStatusValue,
   BadKnownCtftimeId,
   BadKnownEmail,
   BadKnownName,
   GoodRegister,
 } from '@rctf/types'
-import { asc, count, eq, or, sql } from 'drizzle-orm'
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  inArray,
+  notInArray,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm'
 import { invalidateUserCache } from '../cache/auth-cache'
 import type { TypedRedis } from '../cache/scripts'
 import { createToken, TokenKind } from '../lib/tokens'
@@ -384,15 +401,106 @@ export type AdminUserDetails = AdminUserInfo & {
 export const userNameSearchFilter = (search: string) =>
   sql`(${users.name} % ${search} OR ${search} <% ${users.name})`
 
+export type AdminUsersQuery = {
+  limit: number
+  offset: number
+  search?: string
+  sortBy?: AdminTeamSortBy
+  sortOrder?: AdminTeamSortOrder
+  statuses?: AdminTeamStatus[]
+  excludeStatuses?: AdminTeamStatus[]
+  divisions?: string[]
+  excludeDivisions?: string[]
+}
+
+const adminTeamStatusExpression = sql<AdminTeamStatus>`
+  CASE
+    WHEN ${users.perms} > 0 THEN ${AdminTeamStatusValue.ADMIN}
+    WHEN ${users.banned} THEN ${AdminTeamStatusValue.BANNED}
+    ELSE ${AdminTeamStatusValue.ACTIVE}
+  END
+`
+
+const adminUserSearchFilter = (search: string) => {
+  const emailSearch = `%${search.toLowerCase()}%`
+  return sql`(${userNameSearchFilter(search)} OR lower(${users.email}) like ${emailSearch})`
+}
+
+const adminUserFilters = ({
+  search,
+  statuses,
+  excludeStatuses,
+  divisions,
+  excludeDivisions,
+}: AdminUsersQuery): SQL | undefined => {
+  const filters: (SQL | undefined)[] = [
+    search ? adminUserSearchFilter(search) : undefined,
+  ]
+
+  if (statuses && statuses.length > 0) {
+    filters.push(inArray(adminTeamStatusExpression, statuses))
+  }
+
+  if (excludeStatuses && excludeStatuses.length > 0) {
+    filters.push(notInArray(adminTeamStatusExpression, excludeStatuses))
+  }
+
+  if (divisions && divisions.length > 0) {
+    filters.push(inArray(users.division, divisions))
+  }
+
+  if (excludeDivisions && excludeDivisions.length > 0) {
+    filters.push(notInArray(users.division, excludeDivisions))
+  }
+
+  return and(...filters)
+}
+
+const adminUserSortOrder = ({
+  search,
+  sortBy,
+  sortOrder,
+}: AdminUsersQuery): SQL[] => {
+  if (search && !sortBy) {
+    return [
+      sql`similarity(${users.name}, ${search}) DESC`,
+      asc(users.createdAt),
+    ]
+  }
+
+  const direction = sortOrder === AdminTeamSortOrderValue.DESC ? desc : asc
+  const solveCount = count(solves.id)
+
+  switch (sortBy ?? AdminTeamSortByValue.CREATED_AT) {
+    case AdminTeamSortByValue.TEAM:
+      return [direction(users.name), asc(users.createdAt), asc(users.id)]
+    case AdminTeamSortByValue.EMAIL:
+      return [direction(users.email), asc(users.createdAt), asc(users.id)]
+    case AdminTeamSortByValue.DIVISION:
+      return [direction(users.division), asc(users.createdAt), asc(users.id)]
+    case AdminTeamSortByValue.SCORE:
+      return [direction(users.score), asc(users.createdAt), asc(users.id)]
+    case AdminTeamSortByValue.SOLVES:
+      return [direction(solveCount), asc(users.createdAt), asc(users.id)]
+    case AdminTeamSortByValue.STATUS:
+      return [
+        direction(adminTeamStatusExpression),
+        asc(users.createdAt),
+        asc(users.id),
+      ]
+    case AdminTeamSortByValue.CREATED_AT:
+      return [direction(users.createdAt), direction(users.id)]
+  }
+}
+
 export const getAllUsersWithScores = async (
   db: DatabaseClient,
-  limit: number,
-  offset: number,
-  search?: string
+  params: AdminUsersQuery
 ): Promise<{ total: number; users: AdminUserInfo[] }> => {
-  const searchFilter = search ? userNameSearchFilter(search) : undefined
+  const filters = adminUserFilters(params)
+  const solveCount = count(solves.id)
   const [countResult, dbUsers] = await Promise.all([
-    db.select({ count: count() }).from(users).where(searchFilter),
+    db.select({ count: count() }).from(users).where(filters),
     db
       .select({
         id: users.id,
@@ -406,22 +514,15 @@ export const getAllUsersWithScores = async (
         countryCode: users.countryCode,
         statusText: users.statusText,
         createdAt: users.createdAt,
-        solveCount: count(solves.id),
+        solveCount,
       })
       .from(users)
       .leftJoin(solves, eq(users.id, solves.userid))
-      .where(searchFilter)
+      .where(filters)
       .groupBy(users.id)
-      .orderBy(
-        ...(search
-          ? [
-              sql`similarity(${users.name}, ${search}) DESC`,
-              asc(users.createdAt),
-            ]
-          : [asc(users.createdAt)])
-      )
-      .limit(limit)
-      .offset(offset),
+      .orderBy(...adminUserSortOrder(params))
+      .limit(params.limit)
+      .offset(params.offset),
   ])
 
   return {

--- a/packages/types/src/routes/v2/admin.ts
+++ b/packages/types/src/routes/v2/admin.ts
@@ -40,6 +40,8 @@ import {
   GoodUploadsQueryV2,
 } from '../../responses'
 import {
+  AdminTeamSortBy,
+  AdminTeamSortOrder,
   ChallengeFileSchemaV2,
   ChallengePointsSchema,
   MultipleFileFieldSchema,
@@ -64,6 +66,12 @@ export const GetAdminUsersRouteV2 = defineRoute({
     search: z.optional(
       z.string().check(z.minLength(2)).check(z.maxLength(100))
     ),
+    sortBy: z.optional(z.enum(AdminTeamSortBy)),
+    sortOrder: z.optional(z.enum(AdminTeamSortOrder)),
+    statuses: z.optional(z.string().check(z.maxLength(2000))),
+    excludeStatuses: z.optional(z.string().check(z.maxLength(2000))),
+    divisions: z.optional(z.string().check(z.maxLength(2000))),
+    excludeDivisions: z.optional(z.string().check(z.maxLength(2000))),
   }),
   goodResponses: [GoodAdminUsersV2],
   badResponses: [BadBody, BadPerms, BadToken],

--- a/packages/types/src/util/schemas.ts
+++ b/packages/types/src/util/schemas.ts
@@ -89,3 +89,24 @@ export enum AdminBotJobStatus {
   COMPLETED = 'completed',
   FAILED = 'failed',
 }
+
+export enum AdminTeamSortBy {
+  CREATED_AT = 'createdAt',
+  TEAM = 'team',
+  EMAIL = 'email',
+  DIVISION = 'division',
+  SCORE = 'score',
+  SOLVES = 'solves',
+  STATUS = 'status',
+}
+
+export enum AdminTeamSortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+export enum AdminTeamStatus {
+  ACTIVE = 'active',
+  BANNED = 'banned',
+  ADMIN = 'admin',
+}

--- a/tests/server/tests/integration/search.test.ts
+++ b/tests/server/tests/integration/search.test.ts
@@ -1,6 +1,10 @@
 import { config } from '@rctf/config'
 import { createDatabase, solves, users } from '@rctf/db'
 import {
+  AdminTeamSortBy,
+  AdminTeamSortOrder,
+  AdminTeamStatus,
+  BadBody,
   GoodAdminUsersV2,
   GoodLeaderboardV2,
   GoodLeaderboardWithGraph,
@@ -46,6 +50,8 @@ let challengeId: string
 let challengeFlag: string
 let challengeCleanup: () => Promise<void>
 let adminToken: string
+let adminName: string
+let alphaTeamEmail: string
 
 const createNamedUser = async (
   name: string,
@@ -85,6 +91,15 @@ const submitFlag = async (userId: string) => {
   )
 }
 
+const adminUsersUrl = (query: Record<string, string | number>): string => {
+  const params = new URLSearchParams({ limit: '100', offset: '0' })
+  for (const [key, value] of Object.entries(query)) {
+    params.set(key, String(value))
+  }
+
+  return `/api/v2/admin/users?${params.toString()}`
+}
+
 beforeAll(async () => {
   app = await getApp()
 
@@ -99,6 +114,9 @@ beforeAll(async () => {
   await createNamedUser('DeltaForce')
   const alphaTeem = await createNamedUser('AlphaTeem')
   await createNamedUser('Zeta')
+  await createNamedUser('CollegeCrew', 'college')
+  const bannedTeam = await createNamedUser('BannedTeam')
+  alphaTeamEmail = alphaTeam.email
 
   const ch2 = await generateChallenge()
 
@@ -123,18 +141,24 @@ beforeAll(async () => {
   await recomputeLeaderboard()
 
   const db = getDb()
+  await db
+    .update(users)
+    .set({ banned: true })
+    .where(eq(users.id, bannedTeam.id))
+
   const adminId = crypto.randomUUID()
   const adminEmail = `admin-${crypto.randomUUID()}@test.com`
+  adminName = `Admin-${crypto.randomUUID()}`
   await db.insert(users).values({
     id: adminId,
-    name: `Admin-${crypto.randomUUID()}`,
+    name: adminName,
     email: adminEmail,
     division: Object.keys(config.divisions)[0]!,
     perms: Permissions.usersWrite,
   })
   testUsers.push({
     id: adminId,
-    name: 'admin',
+    name: adminName,
     email: adminEmail,
     division: Object.keys(config.divisions)[0]!,
   })
@@ -401,6 +425,21 @@ describe('admin users search', () => {
     expect(names).toContain('AlphaTeam')
   })
 
+  test('search matches email', async () => {
+    const res = await request(
+      app,
+      adminUsersUrl({ search: alphaTeamEmail.toUpperCase() }),
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    const body = await expectResponse(res, GoodAdminUsersV2)
+    const names = body.data.users.map((u: any) => u.name)
+    expect(names).toEqual(['AlphaTeam'])
+    expect(body.data.total).toBe(1)
+  })
+
   test('search with no results returns empty list', async () => {
     const res = await request(
       app,
@@ -438,6 +477,176 @@ describe('admin users search', () => {
 
     expect(bodySearch.data.total).toBeLessThan(bodyAll.data.total)
     expect(bodySearch.data.total).toBe(bodySearch.data.users.length)
+  })
+
+  test('sorts by score descending', async () => {
+    const res = await request(
+      app,
+      adminUsersUrl({
+        sortBy: AdminTeamSortBy.SCORE,
+        sortOrder: AdminTeamSortOrder.DESC,
+      }),
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    const body = await expectResponse(res, GoodAdminUsersV2)
+    const names = body.data.users.map((u: any) => u.name)
+    const alphaTeamIdx = names.indexOf('AlphaTeam')
+    const betaTeamIdx = names.indexOf('BetaTeam')
+
+    expect(alphaTeamIdx).toBeGreaterThanOrEqual(0)
+    expect(betaTeamIdx).toBeGreaterThanOrEqual(0)
+    expect(alphaTeamIdx).toBeLessThan(betaTeamIdx)
+  })
+
+  test('sorts by team name when search is present', async () => {
+    const ascRes = await request(
+      app,
+      adminUsersUrl({
+        search: 'Alpha',
+        sortBy: AdminTeamSortBy.TEAM,
+        sortOrder: AdminTeamSortOrder.ASC,
+      }),
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    const ascBody = await expectResponse(ascRes, GoodAdminUsersV2)
+    expect(ascBody.data.users.map((u: any) => u.name)).toEqual([
+      'AlphaTeam',
+      'AlphaTeem',
+    ])
+
+    const descRes = await request(
+      app,
+      adminUsersUrl({
+        search: 'Alpha',
+        sortBy: AdminTeamSortBy.TEAM,
+        sortOrder: AdminTeamSortOrder.DESC,
+      }),
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    const descBody = await expectResponse(descRes, GoodAdminUsersV2)
+    expect(descBody.data.users.map((u: any) => u.name)).toEqual([
+      'AlphaTeem',
+      'AlphaTeam',
+    ])
+  })
+
+  test('filters by division', async () => {
+    const res = await request(
+      app,
+      '/api/v2/admin/users?limit=100&offset=0&divisions=college',
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    const body = await expectResponse(res, GoodAdminUsersV2)
+    const names = body.data.users.map((u: any) => u.name)
+
+    expect(names).toContain('CollegeCrew')
+    expect(body.data.users.every((u: any) => u.division === 'college')).toBe(
+      true
+    )
+  })
+
+  test('excludes divisions', async () => {
+    const res = await request(
+      app,
+      '/api/v2/admin/users?limit=100&offset=0&search=College&excludeDivisions=college',
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    const body = await expectResponse(res, GoodAdminUsersV2)
+    expect(body.data.users).toHaveLength(0)
+    expect(body.data.total).toBe(0)
+  })
+
+  test('filters by status', async () => {
+    const bannedRes = await request(
+      app,
+      `/api/v2/admin/users?limit=100&offset=0&search=BannedTeam&statuses=${AdminTeamStatus.BANNED}`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    const bannedBody = await expectResponse(bannedRes, GoodAdminUsersV2)
+    expect(bannedBody.data.users.map((u: any) => u.name)).toEqual([
+      'BannedTeam',
+    ])
+    expect(bannedBody.data.users.every((u: any) => u.banned)).toBe(true)
+
+    const adminRes = await request(
+      app,
+      `/api/v2/admin/users?limit=100&offset=0&search=Admin&statuses=${AdminTeamStatus.ADMIN}`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    const adminBody = await expectResponse(adminRes, GoodAdminUsersV2)
+    const names = adminBody.data.users.map((u: any) => u.name)
+    expect(names).toContain(adminName)
+    expect(adminBody.data.users.every((u: any) => u.perms > 0)).toBe(true)
+  })
+
+  test('excludes statuses', async () => {
+    const res = await request(
+      app,
+      adminUsersUrl({
+        search: 'BannedTeam',
+        excludeStatuses: AdminTeamStatus.BANNED,
+      }),
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    const body = await expectResponse(res, GoodAdminUsersV2)
+    expect(body.data.users).toHaveLength(0)
+    expect(body.data.total).toBe(0)
+  })
+
+  test('rejects invalid filters', async () => {
+    const invalidDivisionRes = await request(
+      app,
+      '/api/v2/admin/users?limit=100&offset=0&divisions=nope',
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    await expectResponse(invalidDivisionRes, BadBody)
+
+    const invalidStatusRes = await request(
+      app,
+      '/api/v2/admin/users?limit=100&offset=0&statuses=nope',
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    await expectResponse(invalidStatusRes, BadBody)
+
+    const invalidSortRes = await request(
+      app,
+      '/api/v2/admin/users?limit=100&offset=0&sortBy=nope',
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }
+    )
+    await expectResponse(invalidSortRes, BadBody)
   })
 
   test('pagination with search works', async () => {


### PR DESCRIPTION
## Summary
- add sort and filter query params to GET /v2/admin/users
- apply search, status filters, division filters, and sort order in the users service query
- cover email search, include/exclude filters, sort order, and invalid query values in server integration tests

## API
- GET /v2/admin/users
  - sortBy: createdAt | team | email | division | score | solves | status
  - sortOrder: asc | desc
  - statuses / excludeStatuses: comma-separated active | banned | admin
  - divisions / excludeDivisions: comma-separated configured division ids

## Tests
- bun run --filter '@rctf/types' typecheck
- bun run --filter '@rctf/api' typecheck
- bun run --filter '@rctf/web' typecheck
- bun test tests/integration/search.test.ts
- bun run test:server

Depends on #38.