### PR TITLE
refactor(docker-instancer): default network mode to none

### DIFF
--- a/apps/api/src/providers/instancer/docker-instancer.ts
+++ b/apps/api/src/providers/instancer/docker-instancer.ts
@@ -327,6 +327,7 @@ const defaultService = {
   image: 'traefik/whoami:latest',
   environment: { tiny: 'instancer' },
   networks: [],
+  network_mode: 'none' as const,
   dns: [],
   dns_opt: [],
   dns_search: [],

--- a/apps/docker-instancer/instancer/core/instancer/containers.py
+++ b/apps/docker-instancer/instancer/core/instancer/containers.py
@@ -65,7 +65,7 @@ async def create_container(  # noqa: PLR0913
                 else None,
                 'Labels': merge(container.labels, labels),
                 'HostConfig': {
-                    'NetworkMode': container.network_mode or 'bridge',
+                    'NetworkMode': container.network_mode or ('bridge' if endpoints_config else 'none'),
                     'Mounts': volume_mounts or None,
                     'Dns': container.dns,
                     'DnsOptions': container.dns_opt,

--- a/apps/docs/src/content/docs/integrations/instancer/docker.mdx
+++ b/apps/docs/src/content/docs/integrations/instancer/docker.mdx
@@ -171,3 +171,7 @@ Each service supports these field groups:
 Explicit services default to a read-only root filesystem, `<green>no-new-privileges</green>`, dropped Linux capabilities, `6m` memory, `1.0` CPU, `1024` PIDs, and `nofile` soft and hard limits of `1024`.
 
 Services may only reference networks declared under `<red>config.networks</red>`. Named volume mounts may only reference volumes declared under `<red>config.volumes</red>`. Absolute and relative bind-style mount sources aren't checked against the volume map.
+
+### Network isolation
+
+Challenge workloads are untrusted, so a container is never attached to Docker's shared default bridge unless you ask for it. A service with no `<red>networks</red>`, no `<red>expose</red>`, and no `<red>network_mode</red>` runs detached (`<red>network_mode: none</red>`) rather than on the default bridge. That's what the default config does. When a challenge's services need to talk to each other, declare an internal user-defined network (`<red>internal: true</red>`, as in the example above) and list it under each service's `<red>networks</red>`. That network keeps them off the host and the internet while still connecting them. Set a service's `<red>network_mode</red>` to `<red>bridge</red>` only when you want it on the host's default bridge.


### PR DESCRIPTION
originally reported in SM-MED-1158

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->