### PR TITLE
fix(api): deleting a banned user should not double-reverse

### DIFF
--- a/apps/api/src/services/challenges.ts
+++ b/apps/api/src/services/challenges.ts
@@ -1177,11 +1177,16 @@ export const deleteSolve = async (
   }
 ): Promise<Solve[]> => {
   return await db.transaction(async tx => {
+    await lockChallenge(tx, params.challengeId)
+
+    // share-lock the user row so a concurrent ban can't sweep the same solves
+    // we are about to negate
     const targetUser = await tx
       .select({ banned: users.banned })
       .from(users)
       .where(eq(users.id, params.userId))
       .limit(1)
+      .for('share')
       .then(takeUnique)
 
     const removed = await tx

--- a/apps/api/src/services/solve-points.ts
+++ b/apps/api/src/services/solve-points.ts
@@ -90,6 +90,8 @@ const recomputeDecayWithinTx = async (
   timing: CompetitionTiming,
   maxSolves: number
 ): Promise<{ updatedCount: number; newPoints: number }> => {
+  // share-lock the solver rows so a concurrent ban/unban/delete can't commit
+  // between this read and our score event inserts
   const rows = await tx
     .select({
       id: solves.id,
@@ -102,6 +104,7 @@ const recomputeDecayWithinTx = async (
     .innerJoin(users, eq(users.id, solves.userid))
     .where(eq(solves.challengeid, challenge.id))
     .orderBy(asc(solves.createdat))
+    .for('share', { of: users })
 
   const activeRows = rows.filter(row => !row.banned)
   const firstSolveTime = activeRows[0]

--- a/apps/api/src/services/users.ts
+++ b/apps/api/src/services/users.ts
@@ -747,7 +747,21 @@ export const deleteAdminUser = async (
 
   // collect challengeids before the cascade delete wipes the solves rows
   const affectedDecayIds = await db.transaction(async tx => {
-    await emitUserDeletionScoreEvents(tx, id)
+    const target = await tx
+      .select({ banned: users.banned })
+      .from(users)
+      .where(eq(users.id, id))
+      .limit(1)
+      .for('update')
+      .then(takeUnique)
+    if (!target) {
+      return [] as string[]
+    }
+
+    // a banned user's score events already net to zero
+    if (!target.banned) {
+      await emitUserDeletionScoreEvents(tx, id)
+    }
     const ids = await getAffectedDecayChallengeIds(tx, id)
     await tx.delete(users).where(eq(users.id, id))
     return ids

--- a/tests/server/tests/integration/dynamic-scoring.test.ts
+++ b/tests/server/tests/integration/dynamic-scoring.test.ts
@@ -815,6 +815,29 @@ describe('admin transaction atomicity', () => {
     expect(await sumScoreEvents(user.id, challengeId)).toBe(0)
   })
 
+  test('deleting a banned user does not double-reverse score_events', async () => {
+    const db = getDb()
+    const redis = await createRedis()
+    const { user } = await generateRealTestUser()
+    const challengeId = await createDynamicChallenge()
+
+    await upsertDynamicSolves(db, challengeId, [
+      { userId: user.id, points: 100 },
+    ])
+    await updateAdminUser(db, redis, user.id, { banned: true })
+    expect(await sumScoreEvents(user.id, challengeId)).toBe(0)
+
+    const result = await deleteAdminUser(db, redis, user.id)
+    expect(result.success).toBe(true)
+
+    const rows = await db
+      .select({ delta: scoreEvents.pointsDelta, source: scoreEvents.source })
+      .from(scoreEvents)
+      .where(eq(scoreEvents.challengeid, challengeId))
+    expect(rows.filter(r => r.source === 'delete')).toHaveLength(0)
+    expect(rows.reduce((acc, r) => acc + r.delta, 0)).toBe(0)
+  })
+
   test('delete emits negative events for every solve and removes the user', async () => {
     const db = getDb()
     const redis = await createRedis()


### PR DESCRIPTION
originally reported by hacktron

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->