### PR TITLE
refactor(api): always ratelimit profile

### DIFF
--- a/apps/api/src/routes/v1/users/routes/update-user.ts
+++ b/apps/api/src/routes/v1/users/routes/update-user.ts
@@ -12,13 +12,9 @@ usersGroup.route(UpdateUserRoute, async ({ ctx, user, res, body }) => {
     return res.badDivisionNotAllowed()
   }
 
-  // Limit name updates to 1 per 10 minutes
-  if (body.name !== undefined) {
-    const timeLeft = await rateLimitUpdateProfile(ctx.var.redis, user.id)
-
-    if (timeLeft) {
-      return res.badRateLimit({ timeLeft })
-    }
+  const timeLeft = await rateLimitUpdateProfile(ctx.var.redis, user.id)
+  if (timeLeft) {
+    return res.badRateLimit({ timeLeft })
   }
 
   const result = await updateUserInternal(ctx.var.db, ctx.var.redis, user, {

--- a/apps/api/src/routes/v2/users/routes/update-user.ts
+++ b/apps/api/src/routes/v2/users/routes/update-user.ts
@@ -12,12 +12,9 @@ usersGroup.route(UpdateUserRouteV2, async ({ ctx, user, res, body }) => {
     return res.badDivisionNotAllowed()
   }
 
-  if (body.name !== undefined) {
-    const timeLeft = await rateLimitUpdateProfile(ctx.var.redis, user.id)
-
-    if (timeLeft) {
-      return res.badRateLimit({ timeLeft })
-    }
+  const timeLeft = await rateLimitUpdateProfile(ctx.var.redis, user.id)
+  if (timeLeft) {
+    return res.badRateLimit({ timeLeft })
   }
 
   const result = await updateUserInternal(ctx.var.db, ctx.var.redis, user, {

--- a/apps/docs/src/content/docs/api/users/update.mdx
+++ b/apps/docs/src/content/docs/api/users/update.mdx
@@ -31,14 +31,14 @@ import { BadBody, BadJson, UpdateUserRoute, UpdateUserRouteV2 } from '@rctf/type
 
 <RouteMetaFromDef
   def={UpdateUserRouteV2}
-  rateLimit="Profile name update bucket. Burst `3` and refill window `180000` ms per user."
+  rateLimit="Profile update bucket. Burst `3` and refill window `180000` ms per user."
 />
 
 This route updates profile fields for the authenticated team. Profile changes recalculate cached user data and trigger a leaderboard update.
 
 V2 can update the name, division, country or region code, and status text. V1 can update the name and division.
 
-Name updates use the shared profile name update bucket. Division updates are checked against the divisions allowed for the team's current email address.
+Every update consumes from the shared profile update bucket, regardless of which fields are present. Division updates are checked against the divisions allowed for the team's current email address.
 
 Division changes are rejected once the competition ends, since the division affects the final standings. Other profile fields can still be updated. V2 responds with `badDivisionChangeEnded`, while V1 reports this through `badBody`.
 


### PR DESCRIPTION
originally reported by hacktron
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->