### PR TITLE
refactor(api): migrate from hono's serveStatic

### DIFF
--- a/apps/api/src/providers/uploads/local.ts
+++ b/apps/api/src/providers/uploads/local.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 import type { Hono } from 'hono'
-import { serveStatic } from 'hono/bun'
 import type { AppEnv } from '../../lib/app-env'
 import { encodeKey, UploadProvider, type FileInfo } from './base'
 
@@ -31,20 +30,31 @@ export default class LocalProvider extends UploadProvider {
   }
 
   override async startupWebPart(app: Hono<AppEnv>): Promise<void> {
-    app.use(
-      '/uploads/*',
-      serveStatic({
-        root: this.uploadDirectory,
-        rewriteRequestPath: p => p.replace(/^\/uploads/, ''),
-        onFound: (_path, ctx) => {
-          ctx.res.headers.set(
-            'cache-control',
-            'public, max-age=31557600, immutable'
-          )
-          ctx.res.headers.set('content-disposition', 'attachment')
-        },
-      })
-    )
+    // hono's serveStatic decodes the path with decodeURI, which leaves
+    // reserved characters (& ; + ...) percent-encoded and breaks lookups for
+    // keys produced by encodeKey, so serve files with the exact inverse
+    app.get('/uploads/*', async (c, next) => {
+      let file: ReturnType<typeof Bun.file>
+      try {
+        const key = new URL(c.req.raw.url).pathname
+          .split('/')
+          .slice(2)
+          .map(decodeURIComponent)
+          .join('/')
+
+        file = Bun.file(this.resolveUploadPath(key))
+        if (!(await file.exists())) {
+          return next()
+        }
+      } catch {
+        return next()
+      }
+
+      c.header('content-type', file.type || 'application/octet-stream')
+      c.header('cache-control', 'public, max-age=31557600, immutable')
+      c.header('content-disposition', 'attachment')
+      return c.body(file.stream())
+    })
   }
 
   override uploadFile = async (data: Buffer, key: string): Promise<string> => {

--- a/tests/server/tests/unit/local-upload-provider.test.ts
+++ b/tests/server/tests/unit/local-upload-provider.test.ts
@@ -1,0 +1,44 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import LocalProvider from '../../../../apps/api/src/providers/uploads/local'
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rctf-uploads-test-'))
+const uploadDirectory = path.join(root, 'uploads')
+const provider = new LocalProvider({ uploadDirectory })
+const app = new Hono()
+
+beforeAll(async () => {
+  await provider.startupWebPart(app as any)
+  fs.writeFileSync(path.join(root, 'secret.txt'), 'secret')
+})
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('local upload provider', () => {
+  test('serves filenames with URL-reserved characters', async () => {
+    for (const name of ['!&+.%%_x', '100%.txt']) {
+      const url = await provider.uploadFile(
+        Buffer.from(name),
+        `somehash/${name}`
+      )
+      const res = await app.request(url)
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe(name)
+    }
+  })
+
+  test('does not serve files outside the upload directory', async () => {
+    const target = path.join(uploadDirectory, '..', 'secret.txt')
+    expect(await Bun.file(target).exists()).toBe(true)
+
+    for (const evil of ['..%2Fsecret.txt', '%2e%2e%2fsecret.txt']) {
+      const res = await app.request(`/uploads/${evil}`)
+      expect(res.status).toBe(404)
+    }
+  })
+})


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->