### PR TITLE
fix(tf): enable ADVANCED_DATAPATH for gke deployment example

### DIFF
--- a/apps/docs/src/content/docs/integrations/instancer/kubernetes.md
+++ b/apps/docs/src/content/docs/integrations/instancer/kubernetes.md
@@ -230,7 +230,7 @@ The controller creates three `NetworkPolicy` resources in every instance namespa
 The `<red>exposed</red>` label is applied automatically based on whether a pod is named by any `<red>expose[]</red>` entry. The `<red>egress</red>` label comes from the per-pod `egress: true{:yml}` flag in `<red>instancerConfig</red>`. Challenges that shouldn't reach the internet leave it `false{:yml}`.
 
 :::note[Cluster network plugin]
-Network policies only enforce isolation when the cluster's CNI supports them. GKE's default dataplane enforces them. On a bare-metal cluster, make sure the chosen CNI honors `NetworkPolicy`.
+Network policies only enforce isolation when the cluster's CNI supports them. The bundled GKE Terraform module enables GKE Dataplane V2, which enforces them. On a bare-metal cluster, make sure the chosen CNI honors `NetworkPolicy`.
 :::
 
 ## Per-pod safety checklist

--- a/deploy/terraform/instancer/modules/gke/gke.tf
+++ b/deploy/terraform/instancer/modules/gke/gke.tf
@@ -12,6 +12,9 @@ resource "google_container_cluster" "cluster" {
     remove_default_node_pool = true
     initial_node_count = 1
 
+    networking_mode = "VPC_NATIVE"
+    datapath_provider = "ADVANCED_DATAPATH"
+
     maintenance_policy {
         recurring_window {
             # We need 48h window of total maintenance time per month, therefore do 12h per week


### PR DESCRIPTION
originally reported by @sy1vi3

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->