### PR TITLE
refactor(api): include challengeid in dynamic signature

### DIFF
--- a/apps/api/src/middlewares/dynamic-challenge-auth.ts
+++ b/apps/api/src/middlewares/dynamic-challenge-auth.ts
@@ -67,7 +67,7 @@ export const dynamicChallengeAuthMiddleware: MiddlewareHandler<AppEnv> = async (
   // subsequent json() call parses from cache
   const raw = await c.req.text()
   const hasher = new Bun.CryptoHasher('sha256', scoring.source.secret)
-  hasher.update(`${timestamp}.${raw}`)
+  hasher.update(`${timestamp}.${challenge.id}.${raw}`)
   const expected = `sha256=${hasher.digest('hex')}`
   if (!timingSafeEqual(signatureHeader, expected)) {
     return reject(c)

--- a/apps/docs/src/content/docs/admin/scoring.md
+++ b/apps/docs/src/content/docs/admin/scoring.md
@@ -111,7 +111,7 @@ X-RCTF-Signature: sha256=<hex>
 | Header | Description |
 | --- | --- |
 | `<red>X-RCTF-Timestamp</red>` | Unix milliseconds at signing time. Requests outside a five-minute skew window are rejected. |
-| `<red>X-RCTF-Signature</red>` | `<green>sha256=</green>` followed by the lowercase hex HMAC-SHA256 of `<green>${timestamp}.${raw_body}</green>` using the challenge's `<red>secret</red>`. |
+| `<red>X-RCTF-Signature</red>` | `<green>sha256=</green>` followed by the lowercase hex HMAC-SHA256 of `<green>${timestamp}.${challenge_id}.${raw_body}</green>` using the challenge's `<red>secret</red>`. The challenge ID is the `:id` path parameter, so a signature only works for the challenge it was signed for. |
 
 The route accepts any IP and doesn't require an authenticated rCTF user. Only the HMAC, the timestamp window, and the replay check stand between the open internet and `<red>upsertDynamicSolves</red>`, so the secret is the only thing protecting the scoreboard. Treat it like a password.
 
@@ -139,7 +139,8 @@ export async function publishScores(scores: ScoreEntry[]) {
   const body = JSON.stringify({ scores })
   const timestamp = Date.now().toString()
   const signature =
-    'sha256=' + createHmac('sha256', SECRET).update(`${timestamp}.${body}`).digest('hex')
+    'sha256=' +
+    createHmac('sha256', SECRET).update(`${timestamp}.${CHALLENGE_ID}.${body}`).digest('hex')
 
   const res = await fetch(`${RCTF_BASE_URL}/api/v2/challs/${CHALLENGE_ID}/scores`, {
     method: 'POST',
@@ -165,7 +166,7 @@ rCTF reads the raw request bytes for HMAC verification and only parses JSON afte
 :::
 
 :::note[Retries are safe]
-If a push times out or fails, send the exact same signed request again. rCTF only remembers accepted deliveries (for about ten minutes, per challenge, keyed on the signature), so a failed attempt never blocks the retry. A `409` `<green>badReplayedRequest</green>` on the retry means the first attempt landed after all; count it as a success. Run retries one at a time, and sign every new score update with a fresh timestamp instead of reusing an old signature.
+If a push times out or fails, send the exact same signed request again. rCTF only remembers accepted deliveries (for about ten minutes, keyed on the signature, which is bound to the challenge), so a failed attempt never blocks the retry. A `409` `<green>badReplayedRequest</green>` on the retry means the first attempt landed after all; count it as a success. Run retries one at a time, and sign every new score update with a fresh timestamp instead of reusing an old signature.
 :::
 
 ## How scores reach the leaderboard

--- a/apps/docs/src/content/docs/api/challenges/submit-dynamic-scores.md
+++ b/apps/docs/src/content/docs/api/challenges/submit-dynamic-scores.md
@@ -57,15 +57,15 @@ This route deliberately has neither `onlyWhenStarted` nor `onlyWhenNotFinished`.
 | Header | Value |
 | --- | --- |
 | `X-RCTF-Timestamp` | Unix milliseconds at signing time. Must be within a five-minute skew window of the server clock. |
-| `X-RCTF-Signature` | `sha256=` followed by the lowercase hex HMAC-SHA256 of `${timestamp}.${raw_body}` using the challenge's webhook `secret`. |
+| `X-RCTF-Signature` | `sha256=` followed by the lowercase hex HMAC-SHA256 of `${timestamp}.${challenge_id}.${raw_body}` using the challenge's webhook `secret`. |
 
-Sign the raw request bytes, not the re-serialized JSON. Any difference between the signed bytes and the bytes on the wire (whitespace, key ordering, middleware re-serialization) will fail verification.
+Sign the raw request bytes, not the re-serialized JSON. Any difference between the signed bytes and the bytes on the wire (whitespace, key ordering, middleware re-serialization) will fail verification. The challenge ID in the signed string is the `:id` path parameter, so a signature is only valid for the challenge it was produced for.
 
 Unknown challenge IDs, non-dynamic challenges, mismatched signatures, and timestamps outside the skew window all return the same `<response>401 badSignature</response>` so the endpoint can't be probed for which challenges accept a feed.
 
 rCTF also refuses to apply the same delivery twice. Each accepted signature is remembered for ten minutes, and re-sending the same signed bytes to the same challenge within that window returns `<response>409 badReplayedRequest</response>`, so a captured request can't be replayed against the scoreboard.
 
-Only accepted deliveries are remembered, which makes retries safe. If a push fails or the response gets lost, resend the identical signed request: either it goes through, or it comes back `<response>409 badReplayedRequest</response>` and you know the original attempt was accepted. Retry one attempt at a time, and sign a new request (fresh timestamp, fresh signature) whenever the scores themselves change. The window is tracked per challenge, so one signed payload can still be broadcast to several challenges that share a secret.
+Only accepted deliveries are remembered, which makes retries safe. If a push fails or the response gets lost, resend the identical signed request: either it goes through, or it comes back `<response>409 badReplayedRequest</response>` and you know the original attempt was accepted. Retry one attempt at a time, and sign a new request (fresh timestamp, fresh signature) whenever the scores themselves change. Because the challenge ID is part of the signed string, pushing the same payload to several challenges — even ones sharing a secret — means signing it once per challenge.
 
 ::request-body{def="SubmitDynamicScoresRouteV2" source="params" title="Path parameters"}
 

--- a/tests/dynamic-scoring/lib/harness.ts
+++ b/tests/dynamic-scoring/lib/harness.ts
@@ -206,17 +206,25 @@ export type ScorePayload = {
   scores: ScoreEntry[]
 }
 
+export const signScores = (
+  secret: string,
+  timestamp: string,
+  challengeId: string,
+  body: string
+): string =>
+  `sha256=${createHmac('sha256', secret).update(`${timestamp}.${challengeId}.${body}`).digest('hex')}`
+
 export const signAndPushScores = async (
   challengeId: string,
   secret: string,
   payload: ScorePayload,
-  overrides?: { timestamp?: number; signature?: string }
+  overrides?: { timestamp?: number; signature?: string; signedFor?: string }
 ): Promise<ApiResponse> => {
   const body = JSON.stringify(payload)
   const ts = (overrides?.timestamp ?? Date.now()).toString()
   const sig =
     overrides?.signature ??
-    `sha256=${createHmac('sha256', secret).update(`${ts}.${body}`).digest('hex')}`
+    signScores(secret, ts, overrides?.signedFor ?? challengeId, body)
   return await api(`/api/v2/challs/${challengeId}/scores`, {
     method: 'POST',
     body,

--- a/tests/dynamic-scoring/tests/01-webhook-auth.test.ts
+++ b/tests/dynamic-scoring/tests/01-webhook-auth.test.ts
@@ -117,7 +117,7 @@ describe('webhook auth', () => {
     expect((second.body as { kind?: string }).kind).toBe('goodDynamicScores')
   })
 
-  test('shared secret broadcast to another challenge -> goodDynamicScores', async () => {
+  test('signature for another challenge with a shared secret -> badSignature', async () => {
     sharedSecretChallengeId = testId('chall-auth-shared')
     const created = await createDynamicChallenge(
       admin,
@@ -138,9 +138,9 @@ describe('webhook auth', () => {
       sharedSecretChallengeId,
       SECRET,
       payload,
-      { timestamp }
+      { timestamp, signedFor: challengeId }
     )
-    expect(second.status).toBe(200)
-    expect((second.body as { kind?: string }).kind).toBe('goodDynamicScores')
+    expect(second.status).toBe(401)
+    expect((second.body as { kind?: string }).kind).toBe('badSignature')
   })
 })

--- a/tests/server/tests/integration/webhook-replay.test.ts
+++ b/tests/server/tests/integration/webhook-replay.test.ts
@@ -8,7 +8,12 @@ import {
   scoreEvents,
   type ChallengeData,
 } from '@rctf/db'
-import { BadBody, BadReplayedRequest, GoodDynamicScores } from '@rctf/types'
+import {
+  BadBody,
+  BadReplayedRequest,
+  BadSignature,
+  GoodDynamicScores,
+} from '@rctf/types'
 import { beforeEach, describe, expect, test } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
@@ -52,10 +57,16 @@ const createDynamicChallenge = async (secret = SECRET): Promise<string> => {
   return id
 }
 
-const sign = (secret: string, timestamp: number, body: string) =>
-  `sha256=${createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex')}`
+const sign = (
+  secret: string,
+  timestamp: number,
+  challengeId: string,
+  body: string
+) =>
+  `sha256=${createHmac('sha256', secret).update(`${timestamp}.${challengeId}.${body}`).digest('hex')}`
 
 const signedInit = (
+  challengeId: string,
   body: string,
   timestamp: number,
   secret = SECRET
@@ -65,16 +76,21 @@ const signedInit = (
   headers: {
     'Content-Type': 'application/json',
     'X-RCTF-Timestamp': timestamp.toString(),
-    'X-RCTF-Signature': sign(secret, timestamp, body),
+    'X-RCTF-Signature': sign(secret, timestamp, challengeId, body),
   },
 })
 
-const push = async (challengeId: string, body: string, timestamp: number) => {
+const push = async (
+  challengeId: string,
+  body: string,
+  timestamp: number,
+  signedFor = challengeId
+) => {
   const app = await getApp()
   return await request(
     app,
     `/api/v2/challs/${challengeId}/scores`,
-    signedInit(body, timestamp)
+    signedInit(signedFor, body, timestamp)
   )
 }
 
@@ -112,14 +128,17 @@ describe('webhook replay protection', () => {
     )
   })
 
-  test('one signed payload can be broadcast to challenges sharing a secret', async () => {
+  test('a signature for one challenge is rejected on another sharing a secret', async () => {
     const challengeA = await createDynamicChallenge()
     const challengeB = await createDynamicChallenge()
     const body = JSON.stringify({ scores: [] })
     const ts = Date.now()
 
     await expectResponse(await push(challengeA, body, ts), GoodDynamicScores)
-    await expectResponse(await push(challengeB, body, ts), GoodDynamicScores)
+    await expectResponse(
+      await push(challengeB, body, ts, challengeA),
+      BadSignature
+    )
   })
 
   test('a rejected (4xx) delivery does not consume the dedup slot', async () => {
@@ -157,13 +176,13 @@ describe('webhook replay protection', () => {
     const ts = Date.now()
     const path = `/challs/${challengeId}/scores`
 
-    const first = await app.request(path, signedInit(body, ts))
+    const first = await app.request(path, signedInit(challengeId, body, ts))
     expect(first.status).toBe(500)
 
-    const second = await app.request(path, signedInit(body, ts))
+    const second = await app.request(path, signedInit(challengeId, body, ts))
     expect(second.status).toBe(200)
 
-    const third = await app.request(path, signedInit(body, ts))
+    const third = await app.request(path, signedInit(challengeId, body, ts))
     await expectResponse(third, BadReplayedRequest)
     expect(calls).toBe(2)
   })


### PR DESCRIPTION
resolves #114 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->