### PR TITLE
fix(api): defer mid-tick solves instead of dropping them

### DIFF
--- a/apps/api/src/services/leaderboard.ts
+++ b/apps/api/src/services/leaderboard.ts
@@ -447,8 +447,7 @@ const processSolveBatch = (
         // dynamic challenges accept late deliveries
         const ch = state.challengeInfos.get(solve.challengeid)
         if (!ch || ch.scoringKind !== ChallengeScoringKind.DYNAMIC) {
-          hadUnappliedSolves = true
-          continue
+          break
         }
       }
 

--- a/tests/server/tests/integration/leaderboard-cache.test.ts
+++ b/tests/server/tests/integration/leaderboard-cache.test.ts
@@ -1589,6 +1589,74 @@ describe('edge cases', () => {
   })
 })
 
+describe('mid-tick solves are deferred, not dropped (future-timestamp regression)', () => {
+  test('solve stamped after the rebuild captured its timestamp is applied later', async () => {
+    const db = getDb()
+    const user = await insertUser()
+    const challenge = await insertChallenge()
+
+    await insertSolve({
+      challengeId: challenge.id,
+      userId: user.id,
+      createdAt: isoAt(T1),
+    })
+
+    const calc = createCachedLeaderboardCalculator()
+    const originalNow = Date.now
+    try {
+      Date.now = () => T0
+      const during = await calc(db)
+      expect(during.calculated.users).toHaveLength(0)
+
+      Date.now = () => T2
+      const after = await calc(db)
+      expect(after.recomputedFromScratch).toBe(false)
+      expect(after.calculated.users).toHaveLength(1)
+      expect(after.calculated.challengeInfos.get(challenge.id)?.solves).toBe(1)
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  test('solve stamped after an incremental tick captured its timestamp is applied later', async () => {
+    const db = getDb()
+    const userA = await insertUser()
+    const userB = await insertUser()
+    const challenge = await insertChallenge()
+
+    await insertSolve({
+      challengeId: challenge.id,
+      userId: userA.id,
+      createdAt: isoAt(T0),
+    })
+
+    const calc = createCachedLeaderboardCalculator()
+    const originalNow = Date.now
+    try {
+      Date.now = () => T1
+      await calc(db)
+
+      await insertSolve({
+        challengeId: challenge.id,
+        userId: userB.id,
+        createdAt: isoAt(T3),
+      })
+
+      Date.now = () => T2
+      const during = await calc(db)
+      expect(during.calculated.users).toHaveLength(1)
+
+      Date.now = () => T4
+      const after = await calc(db)
+      expect(after.recomputedFromScratch).toBe(false)
+      expect(after.calculated.users).toHaveLength(2)
+      expect(after.calculated.challengeInfos.get(challenge.id)?.solves).toBe(2)
+    } finally {
+      Date.now = originalNow
+    }
+  })
+})
+
 describe('rebuild uses fresh snapshots (stale-snapshot regression)', () => {
   test('user created after initial snapshot is visible after rebuild', async () => {
     const db = getDb()


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->