### PR TITLE
refactor(web-new): spring-clean readability hotspots

### DIFF
--- a/apps/web-new/src/lib/chart/ticks.ts
+++ b/apps/web-new/src/lib/chart/ticks.ts
@@ -30,8 +30,7 @@ export function ctfRelativeTicks(
   const step = span / (count - 1)
   const ticks: Tick[] = []
   for (let i = 0; i < count; i++) {
-    const value =
-      i === 0 ? startMs : i === count - 1 ? endMs : startMs + step * i
+    const value = i === count - 1 ? endMs : startMs + step * i
     ticks.push({ value, label: format(value, startMs) })
   }
   return ticks

--- a/apps/web-new/src/routes/admin/challenges/details/details-form.svelte
+++ b/apps/web-new/src/routes/admin/challenges/details/details-form.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { ChallengeScoringKind, DynamicScoringTransport, type InstancerConfig } from '@rctf/types'
-  import Markdown from '$lib/components/markdown.svelte'
   import IconChevronDown from '$lib/icons/icon-chevron-down.svelte'
   import IconCloudComputingFilled from '$lib/icons/icon-cloud-computing-filled.svelte'
   import IconEyeFilled from '$lib/icons/icon-eye-filled.svelte'
@@ -89,6 +88,9 @@
     description: false,
     flag: false,
   })
+
+  type TouchedField = keyof typeof touched
+  const showError = (field: TouchedField) => touched[field] && Boolean(errors[field])
 
   const tabItems = $derived([
     {
@@ -213,57 +215,56 @@
 </script>
 
 <challenge-form>
+  {#snippet fieldError(field: TouchedField)}
+    {#if showError(field)}<field-error>{errors[field]}</field-error>{/if}
+  {/snippet}
+
   <form-tabs>
     <Tabs bind:value={tab} tabs={tabItems}>
       {#snippet content({ value })}
         {#if value === 'details'}
           <FormScroll {disabled}>
             <field-grid>
-              <form-field
-                bind:this={nameFieldEl}
-                data-invalid={touched.name && errors.name ? '' : undefined}
-              >
+              <form-field bind:this={nameFieldEl} data-invalid={showError('name') ? '' : undefined}>
                 <field-label>Name<req>*</req></field-label>
                 <Input
                   type="text"
                   placeholder="Challenge name"
                   value={form.name}
                   {disabled}
-                  aria-invalid={touched.name && Boolean(errors.name)}
+                  aria-invalid={showError('name')}
                   oninput={e => onFieldChange('name', e.currentTarget.value)}
                   onblur={() => (touched.name = true)}
                 />
-                {#if touched.name && errors.name}<field-error>{errors.name}</field-error>{/if}
+                {@render fieldError('name')}
               </form-field>
-              <form-field data-invalid={touched.category && errors.category ? '' : undefined}>
+              <form-field data-invalid={showError('category') ? '' : undefined}>
                 <field-label>Category<req>*</req></field-label>
                 <Input
                   type="text"
                   placeholder="web, pwn, crypto, etc."
                   value={form.category}
                   {disabled}
-                  aria-invalid={touched.category && Boolean(errors.category)}
+                  aria-invalid={showError('category')}
                   oninput={e => onFieldChange('category', e.currentTarget.value)}
                   onblur={() => (touched.category = true)}
                 />
-                {#if touched.category && errors.category}
-                  <field-error>{errors.category}</field-error>
-                {/if}
+                {@render fieldError('category')}
               </form-field>
             </field-grid>
 
-            <form-field data-invalid={touched.author && errors.author ? '' : undefined}>
+            <form-field data-invalid={showError('author') ? '' : undefined}>
               <field-label>Author<req>*</req></field-label>
               <Input
                 type="text"
                 placeholder="Challenge author"
                 value={form.author}
                 {disabled}
-                aria-invalid={touched.author && Boolean(errors.author)}
+                aria-invalid={showError('author')}
                 oninput={e => onFieldChange('author', e.currentTarget.value)}
                 onblur={() => (touched.author = true)}
               />
-              {#if touched.author && errors.author}<field-error>{errors.author}</field-error>{/if}
+              {@render fieldError('author')}
             </form-field>
 
             <form-field>
@@ -277,7 +278,7 @@
               />
             </form-field>
 
-            <form-field data-invalid={touched.description && errors.description ? '' : undefined}>
+            <form-field data-invalid={showError('description') ? '' : undefined}>
               <field-label>
                 Description<req>*</req>
                 <field-hint>(Markdown supported)</field-hint>
@@ -298,16 +299,14 @@
                 rows={12}
                 value={form.description}
                 {disabled}
-                aria-invalid={touched.description && Boolean(errors.description)}
+                aria-invalid={showError('description')}
                 oninput={e => onFieldChange('description', e.currentTarget.value)}
                 onblur={() => (touched.description = true)}
               ></Textarea>
-              {#if touched.description && errors.description}
-                <field-error>{errors.description}</field-error>
-              {/if}
+              {@render fieldError('description')}
             </form-field>
 
-            <form-field data-invalid={touched.flag && errors.flag ? '' : undefined}>
+            <form-field data-invalid={showError('flag') ? '' : undefined}>
               <field-label>
                 Flag{#if !isDynamic}<req>*</req>{/if}
                 {#if isDynamic}<field-hint>(unused for dynamic)</field-hint>{/if}
@@ -318,11 +317,11 @@
                 placeholder={flagPlaceholder}
                 value={isDynamic ? '' : form.flag}
                 disabled={disabled || isDynamic}
-                aria-invalid={touched.flag && Boolean(errors.flag)}
+                aria-invalid={showError('flag')}
                 oninput={e => onFieldChange('flag', e.currentTarget.value)}
                 onblur={() => (touched.flag = true)}
               />
-              {#if touched.flag && errors.flag}<field-error>{errors.flag}</field-error>{/if}
+              {@render fieldError('flag')}
             </form-field>
           </FormScroll>
         {:else if value === 'scoring'}

--- a/apps/web-new/src/routes/admin/settings/+page.svelte
+++ b/apps/web-new/src/routes/admin/settings/+page.svelte
@@ -30,10 +30,13 @@
   import ExternalAuthClients from './external-auth-clients.svelte'
   import {
     buildPatch,
+    clearDirty,
     formatDatetimeLocal,
     initialFormState,
     initialOverrides,
     parseDatetimeLocal,
+    resetGroup,
+    snapshotOverrides,
     sponsorsReducer,
     validateTiming,
     type OriginalOverrides,
@@ -96,57 +99,33 @@
 
   function resetGeneral() {
     if (!form || !defaults) return
-    form.ctfName = { value: defaults.ctfName ?? '', overridden: false, dirty: true }
-    form.faviconUrl = { value: defaults.faviconUrl ?? '', overridden: false, dirty: true }
+    form.ctfName = resetGroup(defaults, 'ctfName')
+    form.faviconUrl = resetGroup(defaults, 'faviconUrl')
   }
 
   function resetTiming() {
     if (!form || !defaults) return
-    form.timing = {
-      startTime: defaults.startTime ?? null,
-      endTime: defaults.endTime ?? null,
-      overridden: false,
-      dirty: true,
-    }
+    form.timing = resetGroup(defaults, 'timing')
   }
 
   function resetLogo() {
     if (!form || !defaults) return
-    form.logo = {
-      light: defaults.logoLightUrl ?? '',
-      dark: defaults.logoDarkUrl ?? '',
-      overridden: false,
-      dirty: true,
-    }
+    form.logo = resetGroup(defaults, 'logo')
   }
 
   function resetHome() {
     if (!form || !defaults) return
-    form.homeContent = { value: defaults.homeContent ?? '', overridden: false, dirty: true }
+    form.homeContent = resetGroup(defaults, 'homeContent')
   }
 
   function resetMeta() {
     if (!form || !defaults) return
-    form.meta = {
-      description: defaults.meta?.description ?? '',
-      imageUrl: defaults.meta?.imageUrl ?? '',
-      overridden: false,
-      dirty: true,
-    }
+    form.meta = resetGroup(defaults, 'meta')
   }
 
   function resetSponsors() {
     if (!form || !defaults) return
-    form.sponsors = {
-      list: (defaults.sponsors ?? []).map(s => ({
-        name: s.name,
-        icon: s.icon,
-        description: s.description,
-        url: s.url ?? '',
-      })),
-      overridden: false,
-      dirty: true,
-    }
+    form.sponsors = resetGroup(defaults, 'sponsors')
     sponsorSelected = 0
   }
 
@@ -207,26 +186,8 @@
 
   function commitBaseline() {
     if (!form) return
-    original = {
-      ctfName: form.ctfName.overridden,
-      faviconUrl: form.faviconUrl.overridden,
-      timing: form.timing.overridden,
-      logo: form.logo.overridden,
-      homeContent: form.homeContent.overridden,
-      meta: form.meta.overridden,
-      sponsors: form.sponsors.overridden,
-    }
-    for (const group of [
-      form.ctfName,
-      form.faviconUrl,
-      form.timing,
-      form.logo,
-      form.homeContent,
-      form.meta,
-      form.sponsors,
-    ]) {
-      group.dirty = false
-    }
+    original = snapshotOverrides(form)
+    clearDirty(form)
   }
 
   async function save() {

--- a/apps/web-new/src/routes/admin/settings/settings-model.test.ts
+++ b/apps/web-new/src/routes/admin/settings/settings-model.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from 'bun:test'
 import {
   buildPatch,
   clampSelected,
+  clearDirty,
   decidePatch,
   emptySponsor,
   formatDatetimeLocal,
   initialFormState,
   initialOverrides,
   parseDatetimeLocal,
+  resetGroup,
+  snapshotOverrides,
   sponsorPayload,
   sponsorsReducer,
   validateTiming,
@@ -332,6 +335,156 @@ describe('initialOverrides', () => {
       meta: false,
       sponsors: false,
     })
+  })
+})
+
+describe('reset builders', () => {
+  const defaults = {
+    ctfName: 'rCTF',
+    faviconUrl: '/fav.ico',
+    startTime: 1000,
+    endTime: 2000,
+    homeContent: '# Welcome',
+    logoLightUrl: '/light.png',
+    logoDarkUrl: '/dark.png',
+    meta: { description: 'A CTF.', imageUrl: '/og.png' },
+    sponsors: [
+      { name: 'osec', icon: '/osec.png', description: 'Research.' },
+      {
+        name: 'acme',
+        icon: '/acme.png',
+        description: 'Widgets.',
+        url: 'https://acme.example',
+      },
+    ],
+  }
+
+  it('resets each group to defaults, un-overridden and dirty', () => {
+    expect(resetGroup(defaults, 'ctfName')).toEqual({
+      value: 'rCTF',
+      overridden: false,
+      dirty: true,
+    })
+    expect(resetGroup({}, 'ctfName')).toEqual({
+      value: '',
+      overridden: false,
+      dirty: true,
+    })
+    expect(resetGroup(defaults, 'faviconUrl')).toEqual({
+      value: '/fav.ico',
+      overridden: false,
+      dirty: true,
+    })
+  })
+
+  it('resets timing to defaults, falling back to null', () => {
+    expect(resetGroup(defaults, 'timing')).toEqual({
+      startTime: 1000,
+      endTime: 2000,
+      overridden: false,
+      dirty: true,
+    })
+    expect(resetGroup({}, 'timing')).toEqual({
+      startTime: null,
+      endTime: null,
+      overridden: false,
+      dirty: true,
+    })
+  })
+
+  it('resets logos to defaults, falling back to empty strings', () => {
+    expect(resetGroup(defaults, 'logo')).toEqual({
+      light: '/light.png',
+      dark: '/dark.png',
+      overridden: false,
+      dirty: true,
+    })
+    expect(resetGroup({}, 'logo')).toEqual({
+      light: '',
+      dark: '',
+      overridden: false,
+      dirty: true,
+    })
+  })
+
+  it('resets home content to the default, falling back to empty', () => {
+    expect(resetGroup(defaults, 'homeContent')).toEqual({
+      value: '# Welcome',
+      overridden: false,
+      dirty: true,
+    })
+    expect(resetGroup({}, 'homeContent')).toEqual({
+      value: '',
+      overridden: false,
+      dirty: true,
+    })
+  })
+
+  it('resets meta to defaults, falling back to empty strings', () => {
+    expect(resetGroup(defaults, 'meta')).toEqual({
+      description: 'A CTF.',
+      imageUrl: '/og.png',
+      overridden: false,
+      dirty: true,
+    })
+    expect(resetGroup({}, 'meta')).toEqual({
+      description: '',
+      imageUrl: '',
+      overridden: false,
+      dirty: true,
+    })
+  })
+
+  it('resets sponsors from the default list, mapping missing urls to empty', () => {
+    expect(resetGroup(defaults, 'sponsors')).toEqual({
+      list: [
+        { name: 'osec', icon: '/osec.png', description: 'Research.', url: '' },
+        {
+          name: 'acme',
+          icon: '/acme.png',
+          description: 'Widgets.',
+          url: 'https://acme.example',
+        },
+      ],
+      overridden: false,
+      dirty: true,
+    })
+    expect(resetGroup({}, 'sponsors')).toEqual({
+      list: [],
+      overridden: false,
+      dirty: true,
+    })
+  })
+})
+
+describe('snapshotOverrides', () => {
+  it('reflects each group override flag independently', () => {
+    const groupKeys = Object.keys(cleanState()) as (keyof SettingsFormState)[]
+    for (const key of groupKeys) {
+      const state = cleanState()
+      state[key].overridden = true
+      expect(snapshotOverrides(state)).toEqual({
+        ...cleanOriginal(),
+        [key]: true,
+      })
+    }
+  })
+
+  it('covers every form group', () => {
+    const snapshot = snapshotOverrides(cleanState())
+    expect(Object.keys(snapshot).toSorted()).toEqual(
+      Object.keys(cleanState()).toSorted()
+    )
+  })
+})
+
+describe('clearDirty', () => {
+  it('clears the dirty bit on every form group', () => {
+    const state = cleanState()
+    const groupKeys = Object.keys(state) as (keyof SettingsFormState)[]
+    for (const key of groupKeys) state[key].dirty = true
+    clearDirty(state)
+    for (const key of groupKeys) expect(state[key].dirty).toBe(false)
   })
 })
 

--- a/apps/web-new/src/routes/admin/settings/settings-model.ts
+++ b/apps/web-new/src/routes/admin/settings/settings-model.ts
@@ -299,6 +299,37 @@ export function initialFormState(
   }
 }
 
+export function resetGroup<K extends keyof SettingsFormState>(
+  defaults: AdminSettingsShape,
+  key: K
+): SettingsFormState[K] {
+  return { ...initialFormState({}, defaults)[key], dirty: true }
+}
+
+const settingsGroupKeys = [
+  'ctfName',
+  'faviconUrl',
+  'timing',
+  'logo',
+  'homeContent',
+  'meta',
+  'sponsors',
+] as const satisfies readonly (keyof SettingsFormState)[]
+
+export function snapshotOverrides(form: SettingsFormState): OriginalOverrides {
+  const snapshot = {} as OriginalOverrides
+  for (const key of settingsGroupKeys) {
+    snapshot[key] = form[key].overridden
+  }
+  return snapshot
+}
+
+export function clearDirty(form: SettingsFormState): void {
+  for (const key of settingsGroupKeys) {
+    form[key].dirty = false
+  }
+}
+
 export function formatDatetimeLocal(
   timestamp: number | null | undefined
 ): string {

--- a/apps/web-new/src/routes/profile/solves/solves.svelte
+++ b/apps/web-new/src/routes/profile/solves/solves.svelte
@@ -72,6 +72,7 @@
   const filteredRows = $derived(filterRows(displayResult.rows, { search: searchQuery, hideSolved }))
   const sortedRows = $derived(sortRowsByMode(filteredRows, sortMode))
   const groups = $derived(groupRowsByCategory(filteredRows))
+  const rowsByCategory = $derived(new Map(groups.map(group => [group.category, group.rows])))
   const categoryNames = $derived(groups.map(group => group.category))
   const stats = $derived(
     computeSolvesStats({
@@ -222,7 +223,7 @@
       <Accordion items={categoryNames} bind:value={openCategories}>
         {#snippet header({ value, props, expanded })}
           {@const config = getCategoryConfig(value)}
-          {@const entries = groups.find(group => group.category === value)?.rows ?? []}
+          {@const entries = rowsByCategory.get(value) ?? []}
           {@const staticEntries = entries.filter(entry => !entry.isDynamic)}
           {@const solvedCount = staticEntries.filter(entry => entry.isSolved).length}
           <solves-group-header data-category-color={config.color}>
@@ -243,7 +244,7 @@
 
         {#snippet content({ value, props })}
           {@const config = getCategoryConfig(value)}
-          {@const entries = groups.find(group => group.category === value)?.rows ?? []}
+          {@const entries = rowsByCategory.get(value) ?? []}
           <solves-group-body data-category-color={config.color} {...props}>
             <ul>
               {#each entries as entry (entry.id)}

--- a/apps/web-new/src/routes/scores/leaderboard/hover-state.test.ts
+++ b/apps/web-new/src/routes/scores/leaderboard/hover-state.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  createTooltipTiming,
+  resolveHoverTarget,
+  type HoverTargetFacts,
+} from './hover-state'
+
+function makeFacts(
+  overrides: Partial<HoverTargetFacts> = {}
+): HoverTargetFacts {
+  return {
+    teamId: 'team-1',
+    hasCell: false,
+    columnId: null,
+    hasSpark: false,
+    overMatrixGap: false,
+    ...overrides,
+  }
+}
+
+describe('resolveHoverTarget — matrix cells', () => {
+  test('over a cell sets the hovered column and row, leaves team state alone', () => {
+    const patch = resolveHoverTarget(
+      makeFacts({ hasCell: true, columnId: 'chall-1' })
+    )
+    expect(patch).toStrictEqual({ columnId: 'chall-1', rowId: 'team-1' })
+  })
+
+  test('over a cell without a column id sets the column to null', () => {
+    const patch = resolveHoverTarget(makeFacts({ hasCell: true }))
+    expect(patch).toStrictEqual({ columnId: null, rowId: 'team-1' })
+  })
+
+  test('off any cell outside the matrix gap clears everything', () => {
+    const patch = resolveHoverTarget(makeFacts())
+    expect(patch).toStrictEqual({
+      columnId: null,
+      rowId: null,
+      teamId: null,
+      solveHighlight: null,
+    })
+  })
+
+  test('over the matrix gap leaves the column and row untouched', () => {
+    const patch = resolveHoverTarget(makeFacts({ overMatrixGap: true }))
+    expect(patch).toStrictEqual({ teamId: null, solveHighlight: null })
+  })
+})
+
+describe('resolveHoverTarget — sparklines', () => {
+  test('over a spark highlights the team and clears column state', () => {
+    const patch = resolveHoverTarget(makeFacts({ hasSpark: true }))
+    expect(patch).toStrictEqual({
+      columnId: null,
+      rowId: null,
+      teamId: 'team-1',
+      solveHighlight: null,
+    })
+  })
+
+  test('over a spark in the matrix gap only touches team state', () => {
+    const patch = resolveHoverTarget(
+      makeFacts({ hasSpark: true, overMatrixGap: true })
+    )
+    expect(patch).toStrictEqual({ teamId: 'team-1', solveHighlight: null })
+  })
+
+  test('over a spark with no team resolves a null team highlight', () => {
+    const patch = resolveHoverTarget(
+      makeFacts({ hasSpark: true, teamId: null, overMatrixGap: true })
+    )
+    expect(patch).toStrictEqual({ teamId: null, solveHighlight: null })
+  })
+
+  test('spark inside a cell sets both column and team state', () => {
+    const patch = resolveHoverTarget(
+      makeFacts({ hasCell: true, columnId: 'chall-1', hasSpark: true })
+    )
+    expect(patch).toStrictEqual({
+      columnId: 'chall-1',
+      rowId: 'team-1',
+      teamId: 'team-1',
+      solveHighlight: null,
+    })
+  })
+})
+
+interface FakeTimer {
+  id: number
+  callback: () => void
+  delayMs: number
+}
+
+function createTimingHarness() {
+  let nextId = 1
+  const pending: FakeTimer[] = []
+  const shows: string[] = []
+  const timing = createTooltipTiming<string>({
+    openDelayMs: 400,
+    cooldownMs: 300,
+    setTimer: (callback, delayMs) => {
+      const id = nextId
+      nextId += 1
+      pending.push({ id, callback, delayMs })
+      return id
+    },
+    clearTimer: id => {
+      const index = pending.findIndex(timer => timer.id === id)
+      if (index !== -1) pending.splice(index, 1)
+    },
+  })
+  const hover = (key: string, isHeader = false) =>
+    timing.pointerOverCell(key, isHeader, () => shows.push(key))
+  const fireNext = () => {
+    const timer = pending.shift()
+    if (!timer) throw new Error('no pending fake timer to fire')
+    timer.callback()
+    return timer
+  }
+  return { timing, pending, shows, hover, fireNext }
+}
+
+describe('createTooltipTiming — opening', () => {
+  test('cold hover schedules show after the open delay and fires once', () => {
+    const { pending, shows, hover, fireNext } = createTimingHarness()
+    expect(hover('a')).toBe('scheduled')
+    expect(shows).toEqual([])
+    expect(pending).toHaveLength(1)
+    expect(fireNext().delayMs).toBe(400)
+    expect(shows).toEqual(['a'])
+    expect(pending).toHaveLength(0)
+  })
+
+  test('pointer staying on the pending cell is a no-op', () => {
+    const { pending, shows, hover } = createTimingHarness()
+    hover('a')
+    expect(hover('a')).toBe('ignored')
+    expect(pending).toHaveLength(1)
+    expect(shows).toEqual([])
+  })
+
+  test('pointer staying on the active cell is a no-op', () => {
+    const { pending, shows, hover, fireNext } = createTimingHarness()
+    hover('a')
+    fireNext()
+    expect(hover('a')).toBe('ignored')
+    expect(pending).toHaveLength(0)
+    expect(shows).toEqual(['a'])
+  })
+
+  test('moving to a second cell before expiry cancels and reschedules', () => {
+    const { pending, shows, hover, fireNext } = createTimingHarness()
+    hover('a')
+    expect(hover('b')).toBe('scheduled')
+    expect(pending).toHaveLength(1)
+    expect(fireNext().delayMs).toBe(400)
+    expect(shows).toEqual(['b'])
+  })
+})
+
+describe('createTooltipTiming — warm re-open', () => {
+  test('warm + header opens immediately without a timer', () => {
+    const { pending, shows, hover, fireNext } = createTimingHarness()
+    hover('a')
+    fireNext()
+    expect(hover('header', true)).toBe('shown')
+    expect(shows).toEqual(['a', 'header'])
+    expect(pending).toHaveLength(0)
+  })
+
+  test('warm + non-header still waits the full delay', () => {
+    const { pending, shows, hover, fireNext } = createTimingHarness()
+    hover('a')
+    fireNext()
+    expect(hover('b')).toBe('scheduled')
+    expect(shows).toEqual(['a'])
+    expect(fireNext().delayMs).toBe(400)
+    expect(shows).toEqual(['a', 'b'])
+    expect(pending).toHaveLength(0)
+  })
+
+  test('cold hover on a header is not immediate', () => {
+    const { hover, fireNext } = createTimingHarness()
+    expect(hover('header', true)).toBe('scheduled')
+    expect(fireNext().delayMs).toBe(400)
+  })
+})
+
+describe('createTooltipTiming — cooldown', () => {
+  test('clear with an active tooltip starts the cooldown', () => {
+    const { pending, hover, fireNext, timing } = createTimingHarness()
+    hover('a')
+    fireNext()
+    timing.clear()
+    expect(pending).toHaveLength(1)
+    expect(pending[0]?.delayMs).toBe(300)
+  })
+
+  test('header re-open while cooling is immediate and cancels the cooldown', () => {
+    const { pending, shows, hover, fireNext, timing } = createTimingHarness()
+    hover('a')
+    fireNext()
+    timing.clear()
+    expect(hover('header', true)).toBe('shown')
+    expect(shows).toEqual(['a', 'header'])
+    expect(pending).toHaveLength(0)
+  })
+
+  test('warm drops only after the cooldown elapses', () => {
+    const { hover, fireNext, timing } = createTimingHarness()
+    hover('a')
+    fireNext()
+    timing.clear()
+    fireNext()
+    expect(hover('header', true)).toBe('scheduled')
+  })
+
+  test('a new active clear while cooling restarts the cooldown', () => {
+    const { pending, hover, fireNext, timing } = createTimingHarness()
+    hover('a')
+    fireNext()
+    timing.clear()
+    hover('header', true)
+    timing.clear()
+    expect(pending).toHaveLength(1)
+    expect(pending[0]?.delayMs).toBe(300)
+  })
+
+  test('clear without an active tooltip only cancels the pending open', () => {
+    const { pending, hover, timing } = createTimingHarness()
+    hover('a')
+    timing.clear()
+    expect(pending).toHaveLength(0)
+    timing.clear()
+    expect(pending).toHaveLength(0)
+  })
+
+  test('warm persists when an active tooltip is replaced by a scheduled open, then cleared', () => {
+    const { pending, hover, timing, fireNext } = createTimingHarness()
+    hover('a')
+    fireNext()
+    expect(hover('b')).toBe('scheduled')
+    timing.clear()
+    expect(pending).toHaveLength(0)
+    expect(hover('h', true)).toBe('shown')
+  })
+})
+
+describe('createTooltipTiming — isCurrent', () => {
+  test('tracks the pending cell, then the active cell, until cleared', () => {
+    const { hover, fireNext, timing } = createTimingHarness()
+    expect(timing.isCurrent('a')).toBe(false)
+    hover('a')
+    expect(timing.isCurrent('a')).toBe(true)
+    expect(timing.isCurrent('b')).toBe(false)
+    fireNext()
+    expect(timing.isCurrent('a')).toBe(true)
+    timing.clear()
+    expect(timing.isCurrent('a')).toBe(false)
+  })
+})
+
+describe('createTooltipTiming — dispose', () => {
+  test('dispose clears both the open and cooldown timers', () => {
+    const { pending, shows, hover, fireNext, timing } = createTimingHarness()
+    hover('a')
+    fireNext()
+    timing.clear()
+    hover('b')
+    expect(pending).toHaveLength(2)
+    timing.dispose()
+    expect(pending).toHaveLength(0)
+    expect(shows).toEqual(['a'])
+  })
+})

--- a/apps/web-new/src/routes/scores/leaderboard/hover-state.ts
+++ b/apps/web-new/src/routes/scores/leaderboard/hover-state.ts
@@ -1,0 +1,126 @@
+export interface HoverTargetFacts {
+  teamId: string | null
+  hasCell: boolean
+  columnId: string | null
+  hasSpark: boolean
+  overMatrixGap: boolean
+}
+
+export interface HoverPatch {
+  columnId?: string | null
+  rowId?: string | null
+  teamId?: string | null
+  solveHighlight?: null
+}
+
+export function resolveHoverTarget(facts: HoverTargetFacts): HoverPatch {
+  const patch: HoverPatch = {}
+  if (facts.hasCell) {
+    patch.columnId = facts.columnId
+    patch.rowId = facts.teamId
+  } else if (!facts.overMatrixGap) {
+    patch.columnId = null
+    patch.rowId = null
+  }
+  if (facts.hasSpark) {
+    patch.teamId = facts.teamId
+    patch.solveHighlight = null
+  } else if (!facts.hasCell) {
+    patch.teamId = null
+    patch.solveHighlight = null
+  }
+  return patch
+}
+
+export type TooltipTimingDeps = {
+  openDelayMs: number
+  cooldownMs: number
+  setTimer: (callback: () => void, delayMs: number) => number
+  clearTimer: (id: number) => void
+}
+
+export type PointerOverCellResult = 'shown' | 'scheduled' | 'ignored'
+
+export type TooltipTiming<K> = {
+  pointerOverCell: (
+    key: K,
+    isHeader: boolean,
+    show: () => void
+  ) => PointerOverCellResult
+  isCurrent: (key: K) => boolean
+  clear: () => void
+  dispose: () => void
+}
+
+export function createTooltipTiming<K>(
+  deps: TooltipTimingDeps
+): TooltipTiming<K> {
+  let warm = false
+  let openTimer: number | undefined
+  let coolTimer: number | undefined
+  let pendingKey: K | null = null
+  let activeKey: K | null = null
+
+  function cancelOpen(): void {
+    if (openTimer !== undefined) deps.clearTimer(openTimer)
+    openTimer = undefined
+    pendingKey = null
+  }
+
+  function cancelCooldown(): void {
+    if (coolTimer !== undefined) deps.clearTimer(coolTimer)
+    coolTimer = undefined
+  }
+
+  function markShown(key: K): void {
+    activeKey = key
+    warm = true
+    cancelCooldown()
+  }
+
+  function pointerOverCell(
+    key: K,
+    isHeader: boolean,
+    show: () => void
+  ): PointerOverCellResult {
+    if (isCurrent(key)) return 'ignored'
+    cancelOpen()
+    if (warm && isHeader) {
+      markShown(key)
+      show()
+      return 'shown'
+    }
+    activeKey = null
+    pendingKey = key
+    openTimer = deps.setTimer(() => {
+      openTimer = undefined
+      pendingKey = null
+      markShown(key)
+      show()
+    }, deps.openDelayMs)
+    return 'scheduled'
+  }
+
+  function isCurrent(key: K): boolean {
+    return key === pendingKey || (activeKey !== null && key === activeKey)
+  }
+
+  function clear(): void {
+    cancelOpen()
+    if (activeKey === null) return
+    activeKey = null
+    cancelCooldown()
+    coolTimer = deps.setTimer(() => {
+      coolTimer = undefined
+      warm = false
+    }, deps.cooldownMs)
+  }
+
+  function dispose(): void {
+    cancelOpen()
+    cancelCooldown()
+    activeKey = null
+  }
+
+  return { pointerOverCell, isCurrent, clear, dispose }
+}

--- a/apps/web-new/src/routes/scores/leaderboard/leaderboard.svelte
+++ b/apps/web-new/src/routes/scores/leaderboard/leaderboard.svelte
@@ -9,6 +9,7 @@
   import ScoresGraph from '../graph/graph.svelte'
   import type { ScoresData } from '../model/data.svelte'
   import {
+    computeVisibleRankWindow,
     getCategoryCellsInnerWidth,
     getChallengeCellsInnerWidth,
     getGraphVisibility,
@@ -24,6 +25,7 @@
     SCORE_ROW_HEIGHT_FULL_PX,
     SCORE_VIRTUAL_OVERSCAN,
   } from './constants'
+  import { createTooltipTiming, resolveHoverTarget } from './hover-state'
   import ScoresHeader from './leaderboard-header.svelte'
   import ScoresScrollbars from './scrollbars.svelte'
   import ScoresSelfRow from './self-row.svelte'
@@ -78,24 +80,14 @@
   let tooltipY = $state(0)
   let tooltipPlace = $state<'top' | 'bottom'>('top')
 
-  const TOOLTIP_OPEN_DELAY_MS = 400
-  const TOOLTIP_COOLDOWN_MS = 300
-  let tooltipWarm = false
-  let openTimer: ReturnType<typeof setTimeout> | undefined
-  let coolTimer: ReturnType<typeof setTimeout> | undefined
-  let pendingCell: Element | null = null
-  let tooltipCell: Element | null = null
-
-  function cancelOpenTimer() {
-    clearTimeout(openTimer)
-    openTimer = undefined
-    pendingCell = null
-  }
-
-  $effect(() => () => {
-    clearTimeout(openTimer)
-    clearTimeout(coolTimer)
+  const tooltipTiming = createTooltipTiming<Element>({
+    openDelayMs: 400,
+    cooldownMs: 300,
+    setTimer: (callback, delayMs) => window.setTimeout(callback, delayMs),
+    clearTimer: id => window.clearTimeout(id),
   })
+
+  $effect(() => () => tooltipTiming.dispose())
 
   let hoveredTeamId = $state<string | null>(null)
   let solveHighlight = $state<{ teamId: string; time: number } | null>(null)
@@ -104,15 +96,8 @@
   let hoveredRowId = $state<string | null>(null)
 
   function clearTooltip() {
-    cancelOpenTimer()
-    if (activeTooltip) {
-      activeTooltip = null
-      tooltipCell = null
-      clearTimeout(coolTimer)
-      coolTimer = setTimeout(() => {
-        tooltipWarm = false
-      }, TOOLTIP_COOLDOWN_MS)
-    }
+    tooltipTiming.clear()
+    activeTooltip = null
   }
 
   function clearHover() {
@@ -148,26 +133,23 @@
 
     const teamId = row?.dataset.teamId ?? null
     const overMatrixGap = row ? !target?.closest('row-team') : !!target?.closest('challenge-header')
-    if (cell) {
-      hoveredColumnId = cell.dataset.col ?? null
-      hoveredRowId = teamId
-    } else if (!overMatrixGap) {
-      hoveredColumnId = null
-      hoveredRowId = null
-    }
-    if (spark) {
-      hoveredTeamId = teamId
-      solveHighlight = null
-    } else if (!cell) {
-      hoveredTeamId = null
-      solveHighlight = null
-    }
+    const hoverPatch = resolveHoverTarget({
+      teamId,
+      hasCell: !!cell,
+      columnId: cell?.dataset.col ?? null,
+      hasSpark: !!spark,
+      overMatrixGap,
+    })
+    if (hoverPatch.columnId !== undefined) hoveredColumnId = hoverPatch.columnId
+    if (hoverPatch.rowId !== undefined) hoveredRowId = hoverPatch.rowId
+    if (hoverPatch.teamId !== undefined) hoveredTeamId = hoverPatch.teamId
+    if (hoverPatch.solveHighlight !== undefined) solveHighlight = null
 
     if (virtual.isScrolling || !cell) {
       clearTooltip()
       return
     }
-    if (cell === pendingCell || (activeTooltip && cell === tooltipCell)) return
+    if (tooltipTiming.isCurrent(cell)) return
     const resolved = resolveCellTooltip(cell.dataset, startTime)
     if (!resolved) {
       clearTooltip()
@@ -178,50 +160,31 @@
     const show = () => {
       const rect = cell.getBoundingClientRect()
       activeTooltip = resolved
-      tooltipCell = cell
       tooltipX = rect.left + rect.width / 2
       tooltipY = isHeader ? rect.bottom : rect.top
       tooltipPlace = isHeader ? 'bottom' : 'top'
-      tooltipWarm = true
-      clearTimeout(coolTimer)
       hoveredTeamId = teamId
       solveHighlight =
         teamId && kind === CELL_KIND.challenge && cell.dataset.solveTime
           ? { teamId, time: Number(cell.dataset.solveTime) }
           : null
     }
-    cancelOpenTimer()
-    if (tooltipWarm && isHeader) {
-      show()
-      return
+    if (tooltipTiming.pointerOverCell(cell, isHeader, show) === 'scheduled') {
+      activeTooltip = null
     }
-    activeTooltip = null
-    pendingCell = cell
-    openTimer = setTimeout(show, TOOLTIP_OPEN_DELAY_MS)
   }
 
   let lastWindow = { minRank: 0, maxRank: 0 }
   const liveWindow = $derived.by(() => {
-    let minRank = 0
-    let maxRank = 0
-    const loaded = data.entries.length
-    if (loaded > 0 && geometry.clientHeight > 0) {
-      const bandTop = geometry.scrollTop + headerOffset
-      const bandBottom = geometry.scrollTop + geometry.clientHeight
-      const rowMid = (index: number) =>
-        headerOffset + index * SCORE_ROW_HEIGHT_FULL_PX + SCORE_ROW_HEIGHT_FULL_PX / 2
-      const first = Math.max(0, Math.ceil((bandTop - rowMid(0)) / SCORE_ROW_HEIGHT_FULL_PX))
-      const last = Math.min(
-        loaded - 1,
-        Math.ceil((bandBottom - rowMid(0)) / SCORE_ROW_HEIGHT_FULL_PX) - 1
-      )
-      if (last >= first) {
-        minRank = first + 1
-        maxRank = last + 1
-      }
-    }
-    if (lastWindow.minRank !== minRank || lastWindow.maxRank !== maxRank) {
-      lastWindow = { minRank, maxRank }
+    const next = computeVisibleRankWindow({
+      scrollTop: geometry.scrollTop,
+      clientHeight: geometry.clientHeight,
+      headerOffset,
+      rowHeight: SCORE_ROW_HEIGHT_FULL_PX,
+      loadedCount: data.entries.length,
+    })
+    if (lastWindow.minRank !== next.minRank || lastWindow.maxRank !== next.maxRank) {
+      lastWindow = next
     }
     return lastWindow
   })

--- a/apps/web-new/src/routes/scores/model/transforms.test.ts
+++ b/apps/web-new/src/routes/scores/model/transforms.test.ts
@@ -10,6 +10,7 @@ import {
   SELF_COLOR,
 } from '../leaderboard/constants'
 import {
+  computeVisibleRankWindow,
   getBloodIndex,
   getCategoryCellsInnerWidth,
   getCategoryGroups,
@@ -561,5 +562,93 @@ describe('getCategoryCellsInnerWidth', () => {
     expect(getCategoryCellsInnerWidth(3)).toBe(
       3 * SCORE_CELL_WIDTH_PX + 2 * SCORE_ROW_GAP_PX
     )
+  })
+})
+
+describe('computeVisibleRankWindow', () => {
+  const desktop = { headerOffset: 192, rowHeight: 68, loadedCount: 100 }
+
+  test('returns the empty window when nothing is loaded', () => {
+    expect(
+      computeVisibleRankWindow({
+        ...desktop,
+        scrollTop: 0,
+        clientHeight: 800,
+        loadedCount: 0,
+      })
+    ).toStrictEqual({ minRank: 0, maxRank: 0 })
+  })
+
+  test('returns the empty window before the viewport has measured', () => {
+    expect(
+      computeVisibleRankWindow({ ...desktop, scrollTop: 0, clientHeight: 0 })
+    ).toStrictEqual({ minRank: 0, maxRank: 0 })
+  })
+
+  test('returns the empty window when no row midpoint falls in the band', () => {
+    expect(
+      computeVisibleRankWindow({
+        scrollTop: 35,
+        clientHeight: 60,
+        headerOffset: 0,
+        rowHeight: 68,
+        loadedCount: 50,
+      })
+    ).toStrictEqual({ minRank: 0, maxRank: 0 })
+  })
+
+  test('counts rows whose midpoints sit inside the desktop band', () => {
+    expect(
+      computeVisibleRankWindow({ ...desktop, scrollTop: 0, clientHeight: 800 })
+    ).toStrictEqual({ minRank: 1, maxRank: 9 })
+  })
+
+  test('offsets the window when scrolled without a header', () => {
+    expect(
+      computeVisibleRankWindow({
+        scrollTop: 340,
+        clientHeight: 680,
+        headerOffset: 0,
+        rowHeight: 68,
+        loadedCount: 50,
+      })
+    ).toStrictEqual({ minRank: 6, maxRank: 15 })
+  })
+
+  test('a band edge exactly on a midpoint includes that row', () => {
+    expect(
+      computeVisibleRankWindow({
+        scrollTop: 170,
+        clientHeight: 68,
+        headerOffset: 0,
+        rowHeight: 68,
+        loadedCount: 50,
+      })
+    ).toStrictEqual({ minRank: 3, maxRank: 3 })
+  })
+
+  test('clamps the window to the loaded row count', () => {
+    expect(
+      computeVisibleRankWindow({
+        ...desktop,
+        scrollTop: 0,
+        clientHeight: 10_000,
+        loadedCount: 3,
+      })
+    ).toStrictEqual({ minRank: 1, maxRank: 3 })
+  })
+
+  test('identical inputs produce value-equal windows for the caller memo', () => {
+    const first = computeVisibleRankWindow({
+      ...desktop,
+      scrollTop: 0,
+      clientHeight: 800,
+    })
+    const nudged = computeVisibleRankWindow({
+      ...desktop,
+      scrollTop: 10,
+      clientHeight: 800,
+    })
+    expect(nudged).toStrictEqual(first)
   })
 })

--- a/apps/web-new/src/routes/scores/model/transforms.ts
+++ b/apps/web-new/src/routes/scores/model/transforms.ts
@@ -409,6 +409,38 @@ export function getRankDeltaByTeam(
   return deltas
 }
 
+export interface RankWindow {
+  minRank: number
+  maxRank: number
+}
+
+export interface RankWindowConfig {
+  scrollTop: number
+  clientHeight: number
+  headerOffset: number
+  rowHeight: number
+  loadedCount: number
+}
+
+export function computeVisibleRankWindow(config: RankWindowConfig): RankWindow {
+  if (config.loadedCount <= 0 || config.clientHeight <= 0) {
+    return { minRank: 0, maxRank: 0 }
+  }
+  const bandTop = config.scrollTop + config.headerOffset
+  const bandBottom = config.scrollTop + config.clientHeight
+  const firstRowMid = config.headerOffset + config.rowHeight / 2
+  const first = Math.max(
+    0,
+    Math.ceil((bandTop - firstRowMid) / config.rowHeight)
+  )
+  const last = Math.min(
+    config.loadedCount - 1,
+    Math.ceil((bandBottom - firstRowMid) / config.rowHeight) - 1
+  )
+  if (last < first) return { minRank: 0, maxRank: 0 }
+  return { minRank: first + 1, maxRank: last + 1 }
+}
+
 export function getEmptyGraphVisibility(): GraphVisibility {
   return { visibleTeamIds: new Set(), contextTeamIds: new Set() }
 }


### PR DESCRIPTION
## Summary

The scoreboard's hover/tooltip machinery, the admin settings reset/baseline plumbing, and the details-form error display are now expressed as small tested units instead of inline component tangles — with byte-identical behavior. This is the spring-cleaning pass over the hotspots a judge-scored readability baseline flagged (recorded in `apps/web-new/docs/optimize/`), shipped as reviewable per-concern commits.

Stacked on #138 (`enscribe/fable-web-rewrite` is the base). Until that branch's latest local commits are pushed, this PR's diff temporarily shows a few of its schema-form commits alongside this branch's own work.

## What changed

| Concern | Before | Now |
|---|---|---|
| Leaderboard hover/tooltip | 60-line pointermove handler mixing warm/cooldown/pending timers with hover tracking | `hover-state.ts`: pure `resolveHoverTarget` patches + `createTooltipTiming` with injected timers (20 tests, no sleeps) |
| Live rank window | Identity-cache mutation inside `$derived.by` | Pure `computeVisibleRankWindow` in `model/transforms.ts` (8 tests); the memo swap stays a plain variable |
| Settings resets/baseline | Six hand-written `resetX` bodies + two hand-enumerated group lists | `resetGroup(defaults, key)` derived from `initialFormState({}, defaults)`; `snapshotOverrides`/`clearDirty` share one key set |
| Details-form errors | 4-part touched/error boilerplate per field | `showError` helper + `fieldError` snippet; the scoring `secret` field stays deliberately ungated |
| Small nits | — | solves category lookup via one derived Map; ticks endpoint-pinning branch made honest; WHY comments on the load-more latch and `schemasDiffer` |

Design notes worth review attention:

- The tooltip controller preserves a base quirk on purpose (warmth survives an active→scheduled→leave sequence with no cooldown) — now pinned by a test so nobody "fixes" it accidentally as part of a refactor.
- `resetGroup` reuses `initialFormState({}, defaults)` rather than re-encoding per-group fallbacks, so reset shapes can't drift from initial shapes.
- Hover patches use absent-key = "leave unchanged" semantics to reproduce the old branch behavior exactly.

## Validation

- `check` 0 errors / 0 warnings (1199 files); 985 bun tests pass (+37 added by this branch); prettier, shellcheck/shfmt, and the Svelte autofixer clean.
- An 8-persona review ran with a line-by-line equivalence audit against the base for every extraction (tooltip transitions, reset shapes, window math, error gating) — no semantic drift found; its two actionable findings (a dead sentinel path in the eval harness under `set -e`, a line-length violation) are fixed in the final commit.
- Browser smoke against the live API: `/scores` header hover renders its tooltip through the new controller; profile solves accordion renders in both sort modes. Admin surfaces need credentials and were covered by the equivalence audit instead.
- Readability judge re-run on the fixed 10-file sample: 4.4 → 4.5 (new modules scored separately to avoid off-sample inflation); recorded as non-gating in the optimize log.

Known advisory (left as-is): `snapshotOverrides` builds via a cast, so exhaustiveness for future settings groups is enforced by a test rather than the compiler.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->