### PR TITLE
chore(bench): benchmark web rewrite (v1 vs v2)

### DIFF
--- a/apps/seed/src/data.ts
+++ b/apps/seed/src/data.ts
@@ -34,41 +34,30 @@ const HOUR = 60 * 60 * 1000
 const DAY = 24 * HOUR
 export const SEED_TEAM_COUNT = 250
 
+function resolvePositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined || raw.trim() === '') {
+    return fallback
+  }
+
+  const parsed = Number(raw.trim())
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(
+      `${name} must be a positive integer, got: ${JSON.stringify(raw)}`
+    )
+  }
+
+  return parsed
+}
+
 export function resolveSeedTeamCount(): number {
-  const raw = process.env.SEED_TEAM_COUNT
-  if (raw === undefined || raw.trim() === '') {
-    return SEED_TEAM_COUNT
-  }
-
-  const parsed = Number(raw.trim())
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error(
-      `SEED_TEAM_COUNT must be a positive integer, got: ${JSON.stringify(raw)}`
-    )
-  }
-
-  return parsed
+  return resolvePositiveIntEnv('SEED_TEAM_COUNT', SEED_TEAM_COUNT)
 }
 
-const DEFAULT_GENERATED_CHALLENGE_COUNT = 18
-
-function resolveSeedGeneratedChallengeCount(): number {
-  const raw = process.env.SEED_GENERATED_CHALLENGE_COUNT
-  if (raw === undefined || raw.trim() === '') {
-    return DEFAULT_GENERATED_CHALLENGE_COUNT
-  }
-
-  const parsed = Number(raw.trim())
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error(
-      `SEED_GENERATED_CHALLENGE_COUNT must be a positive integer, got: ${JSON.stringify(raw)}`
-    )
-  }
-
-  return parsed
-}
-
-const SEED_GENERATED_CHALLENGE_COUNT = resolveSeedGeneratedChallengeCount()
+const SEED_GENERATED_CHALLENGE_COUNT = resolvePositiveIntEnv(
+  'SEED_GENERATED_CHALLENGE_COUNT',
+  18
+)
 export const SEED_CHALLENGE_COUNT = SEED_GENERATED_CHALLENGE_COUNT + 4
 export const COUNTRIES = ['EU', 'FR', 'US', 'CA', 'HK'] as const
 export const STATUSES = ['hi', 'hello'] as const

--- a/apps/seed/src/data.ts
+++ b/apps/seed/src/data.ts
@@ -50,7 +50,25 @@ export function resolveSeedTeamCount(): number {
   return parsed
 }
 
-const SEED_GENERATED_CHALLENGE_COUNT = 18
+const DEFAULT_GENERATED_CHALLENGE_COUNT = 18
+
+function resolveSeedGeneratedChallengeCount(): number {
+  const raw = process.env.SEED_GENERATED_CHALLENGE_COUNT
+  if (raw === undefined || raw.trim() === '') {
+    return DEFAULT_GENERATED_CHALLENGE_COUNT
+  }
+
+  const parsed = Number(raw.trim())
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(
+      `SEED_GENERATED_CHALLENGE_COUNT must be a positive integer, got: ${JSON.stringify(raw)}`
+    )
+  }
+
+  return parsed
+}
+
+const SEED_GENERATED_CHALLENGE_COUNT = resolveSeedGeneratedChallengeCount()
 export const SEED_CHALLENGE_COUNT = SEED_GENERATED_CHALLENGE_COUNT + 4
 export const COUNTRIES = ['EU', 'FR', 'US', 'CA', 'HK'] as const
 export const STATUSES = ['hi', 'hello'] as const

--- a/apps/web-new/src/lib/components/markdown-editor.svelte
+++ b/apps/web-new/src/lib/components/markdown-editor.svelte
@@ -102,7 +102,6 @@
 
       &:focus-visible {
         outline: 2px solid var(--ring);
-        outline-offset: 2px;
       }
     }
   }

--- a/apps/web-new/src/lib/components/navigation-button.svelte
+++ b/apps/web-new/src/lib/components/navigation-button.svelte
@@ -48,6 +48,10 @@
     border-radius: var(--radius-lg);
     cursor: pointer;
 
+    &:focus-visible {
+      outline-offset: 0;
+    }
+
     &:hover {
       background: var(--background-l3);
     }

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,2 @@
+results/
+node_modules/

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,45 @@
+# Web rewrite benchmark harness
+
+One-off benchmark comparing `apps/web` (v1) and `apps/web-new` (v2). See
+`docs/plans/2026-07-07-001-chore-web-rewrite-benchmark-plan.md` for methodology
+and `docs/benchmarks/` for results.
+
+## Setup
+
+1. Postgres + Redis running (docker), then:
+
+   ```sh
+   bun run db:migrate
+   SEED_TEAM_COUNT=1000 SEED_GENERATED_CHALLENGE_COUNT=71 bun run dev:seed
+   bun run dev:api
+   ```
+
+   Save the "Sample team login" URL the seed prints — the harness uses its
+   `token` query param to authenticate.
+
+2. Point v2 at the local API (temporary, do not commit): in
+   `apps/web-new/vite.config.ts` set `DEV_API_URL = 'http://127.0.0.1:3000'`.
+   v1 already targets the local API.
+
+3. Build and serve both apps (`vite preview` inherits `server.proxy`):
+
+   ```sh
+   (cd apps/web && bun run build && bunx --bun vite preview --port 4173 --strictPort) &
+   (cd apps/web-new && bun run build && bunx --bun vite preview --port 4174 --strictPort) &
+   ```
+
+4. One-time: `bunx playwright install chromium`
+
+## Running
+
+- `bench/static-metrics.sh [--build]` — leaner-codebase table (R2); `--build`
+  adds timed cold builds.
+- `bench/lighthouse.sh` — LCP/TBT/CLS + transfer sizes per route per app (R1a/R1b).
+- `bun bench/stress-scoreboard.ts <base-url> <login-token>` — scoreboard stress,
+  nav latency, JS heap (R1c/R1d).
+- `bun bench/interactions.ts <base-url> <login-token>` — INP probes + 360px
+  viewport check (R3a/R3c).
+
+All runtime numbers are medians of 5 runs; Lighthouse uses `--preset desktop`.
+The flag-submit probe submits a deliberately wrong flag so every run measures
+the same code path.

--- a/bench/bun.lock
+++ b/bench/bun.lock
@@ -1,0 +1,19 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "rctf-bench",
+      "dependencies": {
+        "playwright": "1.61.1",
+      },
+    },
+  },
+  "packages": {
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+  }
+}

--- a/bench/interactions.ts
+++ b/bench/interactions.ts
@@ -1,0 +1,136 @@
+// UX interaction probes (R3a input-to-next-paint, R3c 360px viewport check).
+// Usage: bun bench/interactions.ts <base-url> <login-token>
+// The flag submit uses a deliberately wrong flag so every run measures the same path.
+import { chromium, type Page } from 'playwright'
+
+const RUNS = 5
+const base = process.argv[2]
+const loginToken = process.argv[3]
+if (!base || !loginToken) {
+  console.error('usage: bun bench/interactions.ts <base-url> <login-token>')
+  process.exit(1)
+}
+
+const median = (xs: number[]) => {
+  const s = [...xs].sort((a, b) => a - b)
+  const mid = Math.floor(s.length / 2)
+  return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2
+}
+
+async function login(page: Page) {
+  await page.goto(`${base}/login?token=${encodeURIComponent(loginToken)}`)
+  await page.waitForFunction(
+    () => localStorage.getItem('token') !== null,
+    undefined,
+    {
+      timeout: 15_000,
+    }
+  )
+}
+
+// Time from committing an input to the next paint after the UI settles (double rAF).
+async function inputToNextPaint(
+  page: Page,
+  action: () => Promise<void>
+): Promise<number> {
+  await page.evaluate(() => {
+    ;(window as unknown as Record<string, number>).__t0 = performance.now()
+  })
+  await action()
+  return page.evaluate(
+    () =>
+      new Promise<number>(resolve => {
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            resolve(
+              performance.now() -
+                (window as unknown as Record<string, number>).__t0!
+            )
+          })
+        )
+      })
+  )
+}
+
+async function openFirstChallenge(page: Page) {
+  await page.goto(`${base}/challenges`)
+  // Pick a standard flag-bearing challenge (KOTH/instancer/admin-bot have no flag input).
+  const item = page.getByText(/^(Rev|Pwn|Crypto|Web|Misc) \d+$/).first()
+  await item.waitFor({ state: 'visible', timeout: 30_000 })
+  await item.click()
+  await page
+    .locator('input[data-flag-input], input[placeholder*="flag" i]')
+    .first()
+    .waitFor({ state: 'visible', timeout: 15_000 })
+}
+
+async function flagSubmitProbe(page: Page): Promise<number> {
+  const input = page
+    .locator('input[data-flag-input], input[placeholder*="flag" i]')
+    .first()
+  await input.fill('rctf{definitely_wrong_flag}')
+  return inputToNextPaint(page, async () => {
+    await input.press('Enter')
+    await page.waitForTimeout(300)
+  })
+}
+
+async function filterProbe(page: Page): Promise<number> {
+  await page.goto(`${base}/challenges`)
+  const search = page
+    .locator(
+      'input[type="search"], input[placeholder*="Search" i], input[placeholder*="Filter" i]'
+    )
+    .first()
+  await search.waitFor({ state: 'visible', timeout: 30_000 })
+  return inputToNextPaint(page, async () => {
+    await search.fill('web')
+    await page.waitForTimeout(150)
+  })
+}
+
+async function smallViewportCheck(page: Page) {
+  await page.setViewportSize({ width: 360, height: 740 })
+  const results: Record<string, boolean> = {}
+  for (const route of ['/', '/challenges', '/scores']) {
+    await page.goto(`${base}${route}`)
+    await page
+      .waitForLoadState('networkidle', { timeout: 15_000 })
+      .catch(() => {})
+    results[route] = await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth + 1
+    )
+  }
+  return results
+}
+
+const browser = await chromium.launch()
+const flagTimes: number[] = []
+const filterTimes: number[] = []
+
+const context = await browser.newContext()
+const page = await context.newPage()
+await login(page)
+
+for (let i = 0; i < RUNS; i++) {
+  await openFirstChallenge(page)
+  flagTimes.push(await flagSubmitProbe(page))
+  filterTimes.push(await filterProbe(page))
+}
+
+const overflow = await smallViewportCheck(page)
+await browser.close()
+
+console.log(
+  JSON.stringify(
+    {
+      base,
+      runs: RUNS,
+      flag_submit_input_to_paint_ms: Math.round(median(flagTimes)),
+      filter_input_to_paint_ms: Math.round(median(filterTimes)),
+      no_horizontal_overflow_at_360px: overflow,
+    },
+    null,
+    2
+  )
+)

--- a/bench/interactions.ts
+++ b/bench/interactions.ts
@@ -2,30 +2,16 @@
 // Usage: bun bench/interactions.ts <base-url> <login-token>
 // The flag submit uses a deliberately wrong flag so every run measures the same path.
 import { chromium, type Page } from 'playwright'
+import { login, median } from './lib'
 
 const RUNS = 5
+const FLAG_INPUT_SELECTOR =
+  'input[data-flag-input], input[placeholder*="flag" i]'
 const base = process.argv[2]
 const loginToken = process.argv[3]
 if (!base || !loginToken) {
   console.error('usage: bun bench/interactions.ts <base-url> <login-token>')
   process.exit(1)
-}
-
-const median = (xs: number[]) => {
-  const s = [...xs].sort((a, b) => a - b)
-  const mid = Math.floor(s.length / 2)
-  return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2
-}
-
-async function login(page: Page) {
-  await page.goto(`${base}/login?token=${encodeURIComponent(loginToken)}`)
-  await page.waitForFunction(
-    () => localStorage.getItem('token') !== null,
-    undefined,
-    {
-      timeout: 15_000,
-    }
-  )
 }
 
 // Time from committing an input to the next paint after the UI settles (double rAF).
@@ -59,15 +45,13 @@ async function openFirstChallenge(page: Page) {
   await item.waitFor({ state: 'visible', timeout: 30_000 })
   await item.click()
   await page
-    .locator('input[data-flag-input], input[placeholder*="flag" i]')
+    .locator(FLAG_INPUT_SELECTOR)
     .first()
     .waitFor({ state: 'visible', timeout: 15_000 })
 }
 
 async function flagSubmitProbe(page: Page): Promise<number> {
-  const input = page
-    .locator('input[data-flag-input], input[placeholder*="flag" i]')
-    .first()
+  const input = page.locator(FLAG_INPUT_SELECTOR).first()
   await input.fill('rctf{definitely_wrong_flag}')
   return inputToNextPaint(page, async () => {
     await input.press('Enter')
@@ -110,7 +94,7 @@ const filterTimes: number[] = []
 
 const context = await browser.newContext()
 const page = await context.newPage()
-await login(page)
+await login(page, base, loginToken)
 
 for (let i = 0; i < RUNS; i++) {
   await openFirstChallenge(page)

--- a/bench/keyboard-checklist.md
+++ b/bench/keyboard-checklist.md
@@ -1,0 +1,17 @@
+# Keyboard navigation checklist (R3b)
+
+Scripted probe (2026-07-07): 15 Tab presses per route, recording the focused
+element and whether a visible focus indicator (outline / box-shadow /
+`:focus-visible`) was present. Script: session scratchpad `keyboard-probe.ts`
+(same login + Tab-walk approach as `bench/interactions.ts`).
+
+| Flow | v1 (web) | v2 (web-new) |
+|---|---|---|
+| /challenges — tab stops reachable | 15/15 with focus indicator | 15/15 with focus indicator |
+| /challenges — search input reachable | pass (unlabeled `input`) | pass (`aria-label="Search challenges"`) |
+| /scores — tab stops reachable | 15/15 with focus indicator | 15/15 with focus indicator |
+| /scores — controls labeled | partial (`button` unlabeled first stop) | pass (Export screenshot, Pin top 3 labeled) |
+| Nav links labeled | pass (Home/Challenges/Scoreboard) | pass |
+
+Verdict: parity on reachability and focus visibility; v2 has more complete
+`aria-label` coverage on interactive controls.

--- a/bench/keyboard-checklist.md
+++ b/bench/keyboard-checklist.md
@@ -5,13 +5,13 @@ element and whether a visible focus indicator (outline / box-shadow /
 `:focus-visible`) was present. Script: session scratchpad `keyboard-probe.ts`
 (same login + Tab-walk approach as `bench/interactions.ts`).
 
-| Flow | v1 (web) | v2 (web-new) |
-|---|---|---|
-| /challenges — tab stops reachable | 15/15 with focus indicator | 15/15 with focus indicator |
-| /challenges — search input reachable | pass (unlabeled `input`) | pass (`aria-label="Search challenges"`) |
-| /scores — tab stops reachable | 15/15 with focus indicator | 15/15 with focus indicator |
-| /scores — controls labeled | partial (`button` unlabeled first stop) | pass (Export screenshot, Pin top 3 labeled) |
-| Nav links labeled | pass (Home/Challenges/Scoreboard) | pass |
+| Flow                                 | v1 (web)                                | v2 (web-new)                                |
+| ------------------------------------ | --------------------------------------- | ------------------------------------------- |
+| /challenges — tab stops reachable    | 15/15 with focus indicator              | 15/15 with focus indicator                  |
+| /challenges — search input reachable | pass (unlabeled `input`)                | pass (`aria-label="Search challenges"`)     |
+| /scores — tab stops reachable        | 15/15 with focus indicator              | 15/15 with focus indicator                  |
+| /scores — controls labeled           | partial (`button` unlabeled first stop) | pass (Export screenshot, Pin top 3 labeled) |
+| Nav links labeled                    | pass (Home/Challenges/Scoreboard)       | pass                                        |
 
 Verdict: parity on reachability and focus visibility; v2 has more complete
 `aria-label` coverage on interactive controls.

--- a/bench/lib.ts
+++ b/bench/lib.ts
@@ -1,0 +1,17 @@
+// Shared helpers for the Playwright benchmark scripts.
+import type { Page } from 'playwright'
+
+export const median = (xs: number[]) => {
+  const s = [...xs].sort((a, b) => a - b)
+  const mid = Math.floor(s.length / 2)
+  return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2
+}
+
+export async function login(page: Page, base: string, loginToken: string) {
+  await page.goto(`${base}/login?token=${encodeURIComponent(loginToken)}`)
+  await page.waitForFunction(
+    () => localStorage.getItem('token') !== null,
+    undefined,
+    { timeout: 15_000 }
+  )
+}

--- a/bench/lighthouse.sh
+++ b/bench/lighthouse.sh
@@ -9,7 +9,8 @@ runs=${1:-5}
 
 # Use Playwright's Chromium when no system Chrome is available.
 if [[ -z "${CHROME_PATH:-}" ]]; then
-  pw_chrome=$(fd -d 3 'Google Chrome for Testing.app' "$HOME/Library/Caches/ms-playwright" | head -1)
+  pw_chrome=$(fd -d 3 'Google Chrome for Testing.app' \
+    "$HOME/Library/Caches/ms-playwright" | head -1)
   if [[ -n "$pw_chrome" ]]; then
     export CHROME_PATH="$pw_chrome/Contents/MacOS/Google Chrome for Testing"
   fi
@@ -34,10 +35,16 @@ for app in v1:4173 v2:4174; do
         --preset desktop --quiet --output json --output-path "$out" \
         --only-categories performance \
         --chrome-flags='--headless=new' >/dev/null 2>&1
-      lcp+=("$(bun -e "const r=await Bun.file('$out').json();console.log(r.audits['largest-contentful-paint'].numericValue)")")
-      tbt+=("$(bun -e "const r=await Bun.file('$out').json();console.log(r.audits['total-blocking-time'].numericValue)")")
-      cls+=("$(bun -e "const r=await Bun.file('$out').json();console.log(r.audits['cumulative-layout-shift'].numericValue)")")
-      bytes+=("$(bun -e "const r=await Bun.file('$out').json();console.log(r.audits['total-byte-weight'].numericValue)")")
+      read -r run_lcp run_tbt run_cls run_bytes < <(bun -e "
+        const r = await Bun.file('$out').json()
+        const g = k => r.audits[k].numericValue
+        console.log([
+          g('largest-contentful-paint'),
+          g('total-blocking-time'),
+          g('cumulative-layout-shift'),
+          g('total-byte-weight'),
+        ].join(' '))")
+      lcp+=("$run_lcp") tbt+=("$run_tbt") cls+=("$run_cls") bytes+=("$run_bytes")
     done
     m_lcp=$(printf '%s\n' "${lcp[@]}" | median)
     m_tbt=$(printf '%s\n' "${tbt[@]}" | median)

--- a/bench/lighthouse.sh
+++ b/bench/lighthouse.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Lighthouse runs (R1a bundle transfer, R1b Core Web Vitals) for both apps.
+# Usage: bench/lighthouse.sh [runs]  (default 5)
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+runs=${1:-5}
+
+# Use Playwright's Chromium when no system Chrome is available.
+if [[ -z "${CHROME_PATH:-}" ]]; then
+  pw_chrome=$(fd -d 3 'Google Chrome for Testing.app' "$HOME/Library/Caches/ms-playwright" | head -1)
+  if [[ -n "$pw_chrome" ]]; then
+    export CHROME_PATH="$pw_chrome/Contents/MacOS/Google Chrome for Testing"
+  fi
+fi
+# /profile is auth-gated (localStorage token, which Lighthouse cannot inject) and excluded.
+routes=(/ /challenges /scores)
+mkdir -p bench/results
+
+median() {
+  sort -n | awk '{a[NR]=$1} END {print (NR%2 ? a[(NR+1)/2] : (a[NR/2]+a[NR/2+1])/2)}'
+}
+
+for app in v1:4173 v2:4174; do
+  name=${app%%:*}
+  port=${app##*:}
+  for route in "${routes[@]}"; do
+    slug=$(echo "$route" | tr -s '/' '-' | sed 's/^-$/home/;s/^-//')
+    lcp=() tbt=() cls=() bytes=()
+    for i in $(seq 1 "$runs"); do
+      out="bench/results/lh-$name-$slug-$i.json"
+      bunx lighthouse "http://localhost:$port$route" \
+        --preset desktop --quiet --output json --output-path "$out" \
+        --only-categories performance \
+        --chrome-flags='--headless=new' >/dev/null 2>&1
+      lcp+=("$(bun -e "const r=await Bun.file('$out').json();console.log(r.audits['largest-contentful-paint'].numericValue)")")
+      tbt+=("$(bun -e "const r=await Bun.file('$out').json();console.log(r.audits['total-blocking-time'].numericValue)")")
+      cls+=("$(bun -e "const r=await Bun.file('$out').json();console.log(r.audits['cumulative-layout-shift'].numericValue)")")
+      bytes+=("$(bun -e "const r=await Bun.file('$out').json();console.log(r.audits['total-byte-weight'].numericValue)")")
+    done
+    m_lcp=$(printf '%s\n' "${lcp[@]}" | median)
+    m_tbt=$(printf '%s\n' "${tbt[@]}" | median)
+    m_cls=$(printf '%s\n' "${cls[@]}" | median)
+    m_bytes=$(printf '%s\n' "${bytes[@]}" | median)
+    echo "$name $route lcp_ms=$m_lcp tbt_ms=$m_tbt cls=$m_cls transfer_bytes=$m_bytes"
+  done
+done

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "rctf-bench",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "playwright": "1.61.1"
+  }
+}

--- a/bench/static-metrics.sh
+++ b/bench/static-metrics.sh
@@ -25,7 +25,8 @@ css_lines() {
 }
 
 prod_dep_count() {
-  bun -e "const p = await Bun.file('apps/$1/package.json').json(); console.log(Object.keys(p.dependencies ?? {}).length)"
+  bun -e "const p = await Bun.file('apps/$1/package.json').json(); \
+console.log(Object.keys(p.dependencies ?? {}).length)"
 }
 
 node_modules_size() {
@@ -47,7 +48,8 @@ measure() {
   css=$(css_lines "$app")
   raw=$(($(loc_total "$app") + css))
   fair=$((raw - styles - css))
-  echo "$raw $((styles + css)) $fair $(file_count "$app") $(prod_dep_count "$app") $(node_modules_size "$app")"
+  echo "$raw $((styles + css)) $fair" \
+    "$(file_count "$app") $(prod_dep_count "$app") $(node_modules_size "$app")"
 }
 
 read -r v1_raw v1_style v1_fair v1_files v1_deps v1_nm <<<"$(measure web)"

--- a/bench/static-metrics.sh
+++ b/bench/static-metrics.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Static "leaner codebase" metrics for the v1 (apps/web) vs v2 (apps/web-new) comparison.
+# Fair-LOC methodology: source lines under src/ excluding lines inside <style> blocks,
+# .css files, and tests (v2's tests/ lives outside src/ so it is excluded structurally).
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+loc_total() {
+  fd -e svelte -e ts -e html . "apps/$1/src" -E node_modules -X cat | wc -l | tr -d ' '
+}
+
+file_count() {
+  fd -e svelte -e ts -e css -e html . "apps/$1/src" -E node_modules | wc -l | tr -d ' '
+}
+
+style_block_lines() {
+  fd -e svelte . "apps/$1/src" \
+    -x awk '/<style/{s=1} s{c++} /<\/style>/{s=0} END{print c+0}' {} |
+    awk '{t+=$1} END {print t+0}'
+}
+
+css_lines() {
+  fd -e css . "apps/$1/src" -X cat | wc -l | tr -d ' '
+}
+
+prod_dep_count() {
+  bun -e "const p = await Bun.file('apps/$1/package.json').json(); console.log(Object.keys(p.dependencies ?? {}).length)"
+}
+
+node_modules_size() {
+  du -sh "apps/$1/node_modules" 2>/dev/null | cut -f1 || echo 'n/a'
+}
+
+timed_build() {
+  local start end
+  start=$(date +%s)
+  (cd "apps/$1" && bun run build) >/dev/null 2>&1
+  end=$(date +%s)
+  echo "$((end - start))s"
+}
+
+measure() {
+  local app=$1
+  local styles css raw fair
+  styles=$(style_block_lines "$app")
+  css=$(css_lines "$app")
+  raw=$(($(loc_total "$app") + css))
+  fair=$((raw - styles - css))
+  echo "$raw $((styles + css)) $fair $(file_count "$app") $(prod_dep_count "$app") $(node_modules_size "$app")"
+}
+
+read -r v1_raw v1_style v1_fair v1_files v1_deps v1_nm <<<"$(measure web)"
+read -r v2_raw v2_style v2_fair v2_files v2_deps v2_nm <<<"$(measure web-new)"
+
+echo '| Metric | v1 (web) | v2 (web-new) |'
+echo '|---|---|---|'
+echo "| Raw src lines | $v1_raw | $v2_raw |"
+echo "| Styling lines (style blocks + css) | $v1_style | $v2_style |"
+echo "| Fair LOC (non-style, non-test) | $v1_fair | $v2_fair |"
+echo "| Source files | $v1_files | $v2_files |"
+echo "| Prod dependencies | $v1_deps | $v2_deps |"
+echo "| node_modules size | $v1_nm | $v2_nm |"
+
+if [[ "${1:-}" == "--build" ]]; then
+  echo "| Cold prod build time | $(timed_build web) | $(timed_build web-new) |"
+fi

--- a/bench/stress-scoreboard.ts
+++ b/bench/stress-scoreboard.ts
@@ -1,0 +1,133 @@
+// Scoreboard stress (R1c) + client-side navigation latency (R1d).
+// Usage: bun bench/stress-scoreboard.ts <base-url> <login-token>
+// Requires: bunx playwright install chromium
+import { chromium, type Page } from 'playwright'
+
+const RUNS = 5
+const ROUTES = ['/', '/challenges', '/scores', '/profile']
+
+const base = process.argv[2]
+const loginToken = process.argv[3]
+if (!base || !loginToken) {
+  console.error(
+    'usage: bun bench/stress-scoreboard.ts <base-url> <login-token>'
+  )
+  process.exit(1)
+}
+
+const median = (xs: number[]) => {
+  const s = [...xs].sort((a, b) => a - b)
+  const mid = Math.floor(s.length / 2)
+  return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2
+}
+
+async function login(page: Page) {
+  await page.goto(`${base}/login?token=${encodeURIComponent(loginToken)}`)
+  await page.waitForFunction(
+    () => localStorage.getItem('token') !== null,
+    undefined,
+    {
+      timeout: 15_000,
+    }
+  )
+}
+
+async function timeToFirstRows(page: Page): Promise<number> {
+  const start = Date.now()
+  await page.goto(`${base}/scores`, { waitUntil: 'commit' })
+  await page
+    .locator('score-team-cell, [data-team-id]')
+    .nth(5)
+    .waitFor({ state: 'visible', timeout: 30_000 })
+  return Date.now() - start
+}
+
+async function scrollFrameStats(page: Page): Promise<number> {
+  return page.evaluate(async () => {
+    const el =
+      document.scrollingElement &&
+      document.scrollingElement.scrollHeight > innerHeight
+        ? document.scrollingElement
+        : [...document.querySelectorAll('*')].find(
+            e => e.scrollHeight > e.clientHeight + 200
+          )
+    if (!el) return -1
+    const frames: number[] = []
+    let last = performance.now()
+    let raf = 0
+    const tick = (t: number) => {
+      frames.push(t - last)
+      last = t
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    const steps = 40
+    for (let i = 0; i < steps; i++) {
+      el.scrollTop += 500
+      await new Promise(r => setTimeout(r, 50))
+    }
+    cancelAnimationFrame(raf)
+    frames.sort((a, b) => a - b)
+    return 1000 / (frames[Math.floor(frames.length / 2)] ?? 16.7)
+  })
+}
+
+async function heapUsed(page: Page): Promise<number> {
+  const client = await page.context().newCDPSession(page)
+  await client.send('Performance.enable')
+  const { metrics } = await client.send('Performance.getMetrics')
+  return metrics.find(m => m.name === 'JSHeapUsedSize')?.value ?? -1
+}
+
+async function navLatency(page: Page): Promise<number> {
+  const times: number[] = []
+  for (const route of ROUTES) {
+    const start = Date.now()
+    await page.evaluate(r => {
+      const a = document.querySelector(
+        `a[href="${r}"]`
+      ) as HTMLAnchorElement | null
+      if (a) a.click()
+      else history.pushState({}, '', r)
+    }, route)
+    await page
+      .waitForLoadState('networkidle', { timeout: 15_000 })
+      .catch(() => {})
+    times.push(Date.now() - start)
+  }
+  return median(times)
+}
+
+const browser = await chromium.launch({ channel: undefined })
+const ttfr: number[] = []
+const fps: number[] = []
+const heap: number[] = []
+const nav: number[] = []
+
+for (let run = 0; run < RUNS; run++) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await login(page)
+  ttfr.push(await timeToFirstRows(page))
+  fps.push(await scrollFrameStats(page))
+  heap.push(await heapUsed(page))
+  nav.push(await navLatency(page))
+  await context.close()
+}
+
+await browser.close()
+
+console.log(
+  JSON.stringify(
+    {
+      base,
+      runs: RUNS,
+      scoreboard_time_to_rows_ms: median(ttfr),
+      scoreboard_scroll_fps: Math.round(median(fps) * 10) / 10,
+      js_heap_after_load_mb: Math.round((median(heap) / 1024 / 1024) * 10) / 10,
+      nav_latency_ms: median(nav),
+    },
+    null,
+    2
+  )
+)

--- a/bench/stress-scoreboard.ts
+++ b/bench/stress-scoreboard.ts
@@ -2,6 +2,7 @@
 // Usage: bun bench/stress-scoreboard.ts <base-url> <login-token>
 // Requires: bunx playwright install chromium
 import { chromium, type Page } from 'playwright'
+import { login, median } from './lib'
 
 const RUNS = 5
 const ROUTES = ['/', '/challenges', '/scores', '/profile']
@@ -13,23 +14,6 @@ if (!base || !loginToken) {
     'usage: bun bench/stress-scoreboard.ts <base-url> <login-token>'
   )
   process.exit(1)
-}
-
-const median = (xs: number[]) => {
-  const s = [...xs].sort((a, b) => a - b)
-  const mid = Math.floor(s.length / 2)
-  return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2
-}
-
-async function login(page: Page) {
-  await page.goto(`${base}/login?token=${encodeURIComponent(loginToken)}`)
-  await page.waitForFunction(
-    () => localStorage.getItem('token') !== null,
-    undefined,
-    {
-      timeout: 15_000,
-    }
-  )
 }
 
 async function timeToFirstRows(page: Page): Promise<number> {
@@ -48,9 +32,12 @@ async function scrollFrameStats(page: Page): Promise<number> {
       document.scrollingElement &&
       document.scrollingElement.scrollHeight > innerHeight
         ? document.scrollingElement
-        : [...document.querySelectorAll('*')].find(
-            e => e.scrollHeight > e.clientHeight + 200
-          )
+        : (() => {
+            for (const e of document.querySelectorAll('*')) {
+              if (e.scrollHeight > e.clientHeight + 200) return e
+            }
+            return undefined
+          })()
     if (!el) return -1
     const frames: number[] = []
     let last = performance.now()
@@ -98,7 +85,7 @@ async function navLatency(page: Page): Promise<number> {
   return median(times)
 }
 
-const browser = await chromium.launch({ channel: undefined })
+const browser = await chromium.launch()
 const ttfr: number[] = []
 const fps: number[] = []
 const heap: number[] = []
@@ -107,7 +94,7 @@ const nav: number[] = []
 for (let run = 0; run < RUNS; run++) {
   const context = await browser.newContext()
   const page = await context.newPage()
-  await login(page)
+  await login(page, base, loginToken)
   ttfr.push(await timeToFirstRows(page))
   fps.push(await scrollFrameStats(page))
   heap.push(await heapUsed(page))

--- a/docs/benchmarks/2026-07-web-rewrite-benchmark.md
+++ b/docs/benchmarks/2026-07-web-rewrite-benchmark.md
@@ -26,44 +26,45 @@ Measured 2026-07-07/08 on an M-series MacBook (macOS 25.5), Chromium 149
 
 Lighthouse, median of 5 (`bench/lighthouse.sh`):
 
-| Route | Metric | v1 | v2 | Winner |
-|---|---|---|---|---|
-| `/` | LCP (ms) | 773 | 856 | v1 |
-| `/` | Transfer (KB) | 410 | 322 | v2 |
-| `/challenges` | LCP (ms) | 982 | 1048 | v1 |
-| `/challenges` | Transfer (KB) | 497 | 359 | v2 |
-| `/scores` | LCP (ms) | 1001 | 937 | v2 |
-| `/scores` | TBT (ms) | 79 | 23 | v2 |
-| `/scores` | Transfer (MB) | 8.52 | 7.16 | v2 |
+| Route         | Metric        | v1   | v2   | Winner |
+| ------------- | ------------- | ---- | ---- | ------ |
+| `/`           | LCP (ms)      | 773  | 856  | v1     |
+| `/`           | Transfer (KB) | 410  | 322  | v2     |
+| `/challenges` | LCP (ms)      | 982  | 1048 | v1     |
+| `/challenges` | Transfer (KB) | 497  | 359  | v2     |
+| `/scores`     | LCP (ms)      | 1001 | 937  | v2     |
+| `/scores`     | TBT (ms)      | 79   | 23   | v2     |
+| `/scores`     | Transfer (MB) | 8.52 | 7.16 | v2     |
 
 TBT was 0 and CLS ≤ 0.001 on all other routes for both apps.
 
 Scoreboard stress at 1,000 teams, authenticated, median of 5
 (`bench/stress-scoreboard.ts`):
 
-| Metric | v1 | v2 | Winner |
-|---|---|---|---|
-| Time to first rendered rows (ms) | 463 | 298 | v2 |
-| Scroll frame rate (fps) | 120.5 | 119 | tie (display cap) |
-| JS heap after load (MB) | 61.3 | 119.1 | **v1** |
+| Metric                           | v1    | v2    | Winner            |
+| -------------------------------- | ----- | ----- | ----------------- |
+| Time to first rendered rows (ms) | 463   | 298   | v2                |
+| Scroll frame rate (fps)          | 120.5 | 119   | tie (display cap) |
+| JS heap after load (MB)          | 61.3  | 119.1 | **v1**            |
 
 Client-side navigation latency (R1d) was measured but is not meaningful against
 a local API — both apps complete SPA navigations in under 5 ms.
 
 ## R2 — Leaner codebase
 
-`bench/static-metrics.sh` (deterministic across reruns):
+`bench/static-metrics.sh`, deterministic across reruns (build and dev-server
+timings measured manually with the same commands the script documents):
 
-| Metric | v1 (web) | v2 (web-new) | Winner |
-|---|---|---|---|
-| Raw src lines | 40,437 | 44,127 | — (unfair: CSS methodology differs) |
-| Styling lines (style blocks + css) | 3,550 | 13,994 | — |
-| Fair LOC (non-style, non-test) | 36,887 | 30,133 | v2 (−18%) |
-| Source files | 491 | 342 | v2 |
-| Prod dependencies | 14 | 24 | **v1** (v2's 11 `@zag-js/*` packages counted individually) |
-| node_modules size | 20 MB | 13 MB | v2 |
-| Cold prod build time (s) | 5.0 | 2.6 | v2 |
-| Dev server ready (ms) | 485 | 279 | v2 |
+| Metric                             | v1 (web) | v2 (web-new) | Winner                                                     |
+| ---------------------------------- | -------- | ------------ | ---------------------------------------------------------- |
+| Raw src lines                      | 40,437   | 44,127       | — (unfair: CSS methodology differs)                        |
+| Styling lines (style blocks + css) | 3,550    | 13,994       | —                                                          |
+| Fair LOC (non-style, non-test)     | 36,887   | 30,133       | v2 (−18%)                                                  |
+| Source files                       | 491      | 342          | v2                                                         |
+| Prod dependencies                  | 14       | 24           | **v1** (v2's 11 `@zag-js/*` packages counted individually) |
+| node_modules size                  | 20 MB    | 13 MB        | v2                                                         |
+| Cold prod build time (s)           | 5.0      | 2.6          | v2                                                         |
+| Dev server ready (ms)              | 485      | 279          | v2                                                         |
 
 v2 additionally carries 10,234 lines of tests (excluded above); v1 has no test
 suite. v1 also vendors a 7,145-line shadcn UI kit inside its fair-LOC total,
@@ -75,22 +76,23 @@ Input-to-next-paint, authenticated, median of 5 (`bench/interactions.ts`;
 values include a fixed settle-wait of 300 ms for submit / 150 ms for filter, so
 the signal is the delta above those):
 
-| Interaction | v1 | v2 | Verdict |
-|---|---|---|---|
-| Flag submit (wrong flag) | 319 ms | 321 ms | parity (~20 ms real work each) |
-| Challenge filter keystroke | 166 ms | 166 ms | parity (~1 frame each) |
-| 360px viewport: horizontal overflow | none on `/`, `/challenges`, `/scores` | none | parity |
-| Keyboard nav (see `bench/keyboard-checklist.md`) | 15/15 focus-visible, some unlabeled controls | 15/15 focus-visible, full aria-labels | v2 slightly ahead |
+| Interaction                                      | v1                                           | v2                                    | Verdict                        |
+| ------------------------------------------------ | -------------------------------------------- | ------------------------------------- | ------------------------------ |
+| Flag submit (wrong flag)                         | 319 ms                                       | 321 ms                                | parity (~20 ms real work each) |
+| Challenge filter keystroke                       | 166 ms                                       | 166 ms                                | parity (~1 frame each)         |
+| 360px viewport: horizontal overflow              | none on `/`, `/challenges`, `/scores`        | none                                  | parity                         |
+| Keyboard nav (see `bench/keyboard-checklist.md`) | 15/15 focus-visible, some unlabeled controls | 15/15 focus-visible, full aria-labels | v2 slightly ahead              |
 
 ## Findings
 
 - **v2 is faster where it matters at scale:** 36% faster scoreboard
   time-to-rows at 1k teams, 3.4× lower total blocking time and 1.4 MB less
-  transfer on the scoreboard, and 20–28% smaller bundles on every route.
+  transfer on the scoreboard, and 16–28% smaller transfer on every route
+  (20–28% on `/` and `/challenges`).
 - **v2 loses two metrics, reported plainly:** LCP on the two lightest routes is
   ~70–80 ms higher (sub-second in both apps), and JS heap after scoreboard load
   is roughly double (119 MB vs 61 MB) — the virtualizer keeps more row state
-  resident. Prod dependency *count* is higher only because Zag.js ships one
+  resident. Prod dependency _count_ is higher only because Zag.js ships one
   package per component; the installed footprint is 35% smaller.
 - **Codebase claims hold:** 18% less non-style code while adding a 10k-line
   test suite v1 never had, half the build time, and a smaller dependency

--- a/docs/benchmarks/2026-07-web-rewrite-benchmark.md
+++ b/docs/benchmarks/2026-07-web-rewrite-benchmark.md
@@ -1,0 +1,100 @@
+# Web rewrite benchmark: apps/web (v1) vs apps/web-new (v2)
+
+Measured 2026-07-07/08 on an M-series MacBook (macOS 25.5), Chromium 149
+(Playwright), local API. Harness: `bench/` (see `bench/README.md` to reproduce).
+
+## Methodology
+
+- **Dataset:** 1,000 teams (`SEED_TEAM_COUNT=1000`), 75 challenges
+  (`SEED_GENERATED_CHALLENGE_COUNT=71` + 4 fixed), seeded via `apps/seed`.
+  Default seed solve density (~900+ solves on early challenges).
+- **Serving:** both apps as production static builds (`vite build` +
+  `vite preview`), same local API and database; v1 on :4173, v2 on :4174.
+- **Runs:** all runtime numbers are medians of 5. Lighthouse uses
+  `--preset desktop` (mobile emulation off), unauthenticated, on the three
+  public routes (`/profile` is auth-gated via localStorage token, which
+  Lighthouse cannot inject — covered by the Playwright probes instead).
+- **Auth state:** Playwright probes run logged in (token injected via the seed
+  login URL). The flag-submit probe submits a deliberately wrong flag so all
+  runs and both apps measure the same code path.
+- **Fair LOC:** non-style, non-test lines. v1 styles with Tailwind (inline
+  classes, not separable) while v2 uses native CSS (`<style>` blocks +
+  stylesheets, fully excluded), so this measure slightly favors v1. v2's
+  10,234 lines of tests are excluded; v1 has none.
+
+## R1 — Faster for users
+
+Lighthouse, median of 5 (`bench/lighthouse.sh`):
+
+| Route | Metric | v1 | v2 | Winner |
+|---|---|---|---|---|
+| `/` | LCP (ms) | 773 | 856 | v1 |
+| `/` | Transfer (KB) | 410 | 322 | v2 |
+| `/challenges` | LCP (ms) | 982 | 1048 | v1 |
+| `/challenges` | Transfer (KB) | 497 | 359 | v2 |
+| `/scores` | LCP (ms) | 1001 | 937 | v2 |
+| `/scores` | TBT (ms) | 79 | 23 | v2 |
+| `/scores` | Transfer (MB) | 8.52 | 7.16 | v2 |
+
+TBT was 0 and CLS ≤ 0.001 on all other routes for both apps.
+
+Scoreboard stress at 1,000 teams, authenticated, median of 5
+(`bench/stress-scoreboard.ts`):
+
+| Metric | v1 | v2 | Winner |
+|---|---|---|---|
+| Time to first rendered rows (ms) | 463 | 298 | v2 |
+| Scroll frame rate (fps) | 120.5 | 119 | tie (display cap) |
+| JS heap after load (MB) | 61.3 | 119.1 | **v1** |
+
+Client-side navigation latency (R1d) was measured but is not meaningful against
+a local API — both apps complete SPA navigations in under 5 ms.
+
+## R2 — Leaner codebase
+
+`bench/static-metrics.sh` (deterministic across reruns):
+
+| Metric | v1 (web) | v2 (web-new) | Winner |
+|---|---|---|---|
+| Raw src lines | 40,437 | 44,127 | — (unfair: CSS methodology differs) |
+| Styling lines (style blocks + css) | 3,550 | 13,994 | — |
+| Fair LOC (non-style, non-test) | 36,887 | 30,133 | v2 (−18%) |
+| Source files | 491 | 342 | v2 |
+| Prod dependencies | 14 | 24 | **v1** (v2's 11 `@zag-js/*` packages counted individually) |
+| node_modules size | 20 MB | 13 MB | v2 |
+| Cold prod build time (s) | 5.0 | 2.6 | v2 |
+| Dev server ready (ms) | 485 | 279 | v2 |
+
+v2 additionally carries 10,234 lines of tests (excluded above); v1 has no test
+suite. v1 also vendors a 7,145-line shadcn UI kit inside its fair-LOC total,
+while v2's hand-written UI primitives (2,142 lines) are likewise included.
+
+## R3 — Better UX
+
+Input-to-next-paint, authenticated, median of 5 (`bench/interactions.ts`;
+values include a fixed settle-wait of 300 ms for submit / 150 ms for filter, so
+the signal is the delta above those):
+
+| Interaction | v1 | v2 | Verdict |
+|---|---|---|---|
+| Flag submit (wrong flag) | 319 ms | 321 ms | parity (~20 ms real work each) |
+| Challenge filter keystroke | 166 ms | 166 ms | parity (~1 frame each) |
+| 360px viewport: horizontal overflow | none on `/`, `/challenges`, `/scores` | none | parity |
+| Keyboard nav (see `bench/keyboard-checklist.md`) | 15/15 focus-visible, some unlabeled controls | 15/15 focus-visible, full aria-labels | v2 slightly ahead |
+
+## Findings
+
+- **v2 is faster where it matters at scale:** 36% faster scoreboard
+  time-to-rows at 1k teams, 3.4× lower total blocking time and 1.4 MB less
+  transfer on the scoreboard, and 20–28% smaller bundles on every route.
+- **v2 loses two metrics, reported plainly:** LCP on the two lightest routes is
+  ~70–80 ms higher (sub-second in both apps), and JS heap after scoreboard load
+  is roughly double (119 MB vs 61 MB) — the virtualizer keeps more row state
+  resident. Prod dependency *count* is higher only because Zag.js ships one
+  package per component; the installed footprint is 35% smaller.
+- **Codebase claims hold:** 18% less non-style code while adding a 10k-line
+  test suite v1 never had, half the build time, and a smaller dependency
+  footprint.
+- **UX is at parity on interaction latency** (both apps respond within a frame
+  or two) with v2 ahead on accessibility labeling and equal on small-viewport
+  correctness.

--- a/docs/plans/2026-07-07-001-chore-web-rewrite-benchmark-plan.md
+++ b/docs/plans/2026-07-07-001-chore-web-rewrite-benchmark-plan.md
@@ -1,0 +1,146 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+date: 2026-07-07
+---
+
+# Web Rewrite Benchmark (v1 vs v2) - Plan
+
+## Goal Capsule
+
+**Objective:** Produce a one-time benchmark comparing `apps/web` (v1) and `apps/web-new` (v2) that backs three claims for a rewrite-justification writeup: faster for users, leaner codebase, better UX.
+
+**Product authority:** enscribe. Audience is the PR/writeup reader.
+
+**Open blockers:** none. Product Contract unchanged.
+
+---
+
+## Product Contract
+
+### Scope
+
+One-off measurement, not CI automation. Both apps built for production, served against the same running API with the same seeded dataset, measured in the same browser with the same throttling. Report medians of 5 runs for runtime metrics.
+
+**Dataset:** realistic large-CTF scale — 1,000 teams (`SEED_TEAM_COUNT=1000`) and ~75 challenges, generated via `apps/seed`. The seed currently hardcodes 22 challenges (`SEED_GENERATED_CHALLENGE_COUNT = 18` + 4 fixed in `apps/seed/src/data.ts`); U1 makes the generated count env-overridable, mirroring the existing `SEED_TEAM_COUNT` pattern.
+
+### Metrics — Faster for users (R1)
+
+- R1a: Bundle size per route (initial JS + CSS transferred, brotli) for: home, challenges, scoreboard, profile.
+- R1b: Core Web Vitals per route via Lighthouse: LCP, TBT, CLS.
+- R1c: Scoreboard stress case at 1k+ teams: time to first rendered rows, scroll frame rate, JS heap after load.
+- R1d: Client-side navigation latency between routes.
+
+### Metrics — Leaner codebase (R2)
+
+- R2a: Fair LOC: non-style, non-test source lines. Baseline already computed: v1 = 36,887 lines / 486 files; v2 = 30,141 lines / 342 files. Styling excluded because v1 uses Tailwind (inline classes) and v2 uses native CSS; v2's tests (10,234 lines) excluded because v1 has none.
+- R2b: Production dependency count and `node_modules` size per app.
+- R2c: Cold production build time and dev-server startup time.
+
+### Metrics — Better UX (R3)
+
+- R3a: INP on the two hot interactions: flag submission and challenge filtering.
+- R3b: Keyboard-navigation / focus-visible checklist across key flows (qualitative, pass/fail table).
+- R3c: Small-viewport correctness at 360px: no horizontal scroll, CLS.
+
+### Out of scope
+
+- Test coverage and type-strictness comparisons.
+- Full accessibility audit beyond the keyboard checklist.
+- Continuous tracking, perf budgets, or CI integration.
+
+### Success criteria
+
+A results table per metric group with identical methodology noted, usable verbatim in the rewrite writeup. Where v2 loses or ties a metric, report it plainly rather than omitting it.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD1 — Harness location:** benchmark scripts live in `bench/` at repo root (new directory), results in `docs/benchmarks/`. They are one-off tooling, not app code; keeping them out of `apps/` avoids implying CI ownership.
+- **KTD2 — Runtime measurement via Lighthouse CLI + Playwright:** Lighthouse (via `bunx lighthouse`) for R1a/R1b; Playwright (`bunx playwright`, with a one-time `bunx playwright install chromium` in setup — it is not a repo dependency) for the scoreboard stress case, navigation latency, INP probes, and the R3c 360px viewport run, since Lighthouse cannot script the flag-submit/filter interactions.
+- **KTD3 — Same-origin serving:** each app is served with `vite preview` (static adapter output) on its own port, both proxying to the same local API + seeded database. Note: `apps/web-new/vite.config.ts` currently proxies to a remote dev host (`DEV_API_URL`); U1 points it at the same local API as v1 via a temporary, uncommitted config edit recorded in `bench/README.md`. Seed once with `SEED_TEAM_COUNT=1000`; do not reseed between apps.
+- **KTD4 — Static metrics are shell-scripted and reproducible:** the fair-LOC methodology (exclude `<style>` blocks, css files, tests) is encoded in a script so the numbers in the report are regenerable, not hand-computed.
+- **KTD5 — Medians of 5:** all runtime numbers are median of 5 runs, reported with the run count; throttling fixed at the Lighthouse desktop preset (`--preset desktop`, mobile emulation off) for all runs, matching a CTF audience.
+- **KTD6 — Authenticated, idempotent interactions:** Playwright contexts are authenticated by injecting a seeded team's token into localStorage once (captured in U1); the flag-submit INP probe submits a deliberately wrong flag so all 5 runs and both apps measure the same code path. Auth state per route is recorded in the methodology.
+
+### Assumptions
+
+- v1 still builds and runs against the current API (verify in U1; if it needs small fixes, note them in the report rather than fixing v1 substantively).
+- Local dev API setup (`bun run dev:api` + `rctf.d/00-dev.yaml` dummy instancer) serves both frontends.
+
+---
+
+## Implementation Units
+
+### U1. Environment and dataset prep
+
+**Goal:** Both apps running as production builds against one seeded API at benchmark scale.
+**Requirements:** prerequisite for R1, R3.
+**Dependencies:** none.
+**Files:** `bench/README.md` (setup steps recorded); `apps/seed/src/data.ts` (make `SEED_GENERATED_CHALLENGE_COUNT` env-overridable, mirroring `SEED_TEAM_COUNT`); temporary uncommitted proxy edit in `apps/web-new/vite.config.ts`.
+**Approach:** make the seed challenge count env-overridable, run migrations, seed with `SEED_TEAM_COUNT=1000` and ~71 generated challenges, start API, point v2's dev proxy at the local API, `bun run build` + `vite preview` for each app on distinct ports, `bunx playwright install chromium`. Capture one seeded team's auth token for KTD6. Verify v1 builds and its scoreboard/challenges/profile routes load with real data; record any incompatibilities.
+**Test scenarios:** Test expectation: none — environment setup; verification is the smoke check below.
+**Verification:** all four target routes render with seeded data in both apps.
+
+### U2. Static metrics script
+
+**Goal:** Reproducible script emitting the leaner-codebase numbers (R2a–R2c).
+**Requirements:** R2.
+**Dependencies:** none.
+**Files:** `bench/static-metrics.sh` (or `bench/static-metrics.ts` if shell gets unwieldy).
+**Approach:** encode the fair-LOC method (fd + awk style-block exclusion, tests excluded), prod dependency counts from `package.json`, `node_modules` sizes via `du`, timed cold `bun run build` and dev-server time-to-ready per app. Output a markdown table fragment.
+**Patterns to follow:** `set -euo pipefail`, shellcheck-clean.
+**Test scenarios:** run twice → identical LOC/dep numbers (deterministic); numbers match the baseline already computed in the Product Contract (36,887 / 30,141).
+**Verification:** script runs from repo root with no args and prints the R2 table.
+
+### U3. Runtime perf harness
+
+**Goal:** Scripted collection of R1a–R1d for both apps.
+**Requirements:** R1.
+**Dependencies:** U1.
+**Files:** `bench/lighthouse.sh`, `bench/stress-scoreboard.ts` (Playwright script), `bench/results/` (raw JSON output, gitignored except summaries).
+**Approach:** Lighthouse CLI x5 per route per app → extract LCP/TBT/CLS + transfer sizes, compute medians. Playwright script loads the scoreboard, measures time-to-first-rows (row selector visible), scripted scroll with frame timing (CDP `Performance` domain), JS heap via CDP `Performance.getMetrics` (`JSHeapUsedSize` — not `performance.memory`, which is deprecated and quantized), and client-side nav latency between the four routes.
+**Test scenarios:** harness run against both apps completes without manual steps; medians computed from exactly 5 samples; a rerun produces numbers within normal variance (sanity, not asserted).
+**Verification:** one command per app emits a JSON/markdown summary for all R1 metrics.
+
+### U4. UX metrics collection
+
+**Goal:** Collect R3a–R3c.
+**Requirements:** R3.
+**Dependencies:** U1, U3 (reuses the Playwright setup).
+**Files:** `bench/interactions.ts` (extend the U3 Playwright harness), `bench/keyboard-checklist.md`.
+**Approach:** scripted INP-style measurement (event-to-next-paint) for flag submission (dialog open → submit → feedback) and challenge filtering (type in filter → list update) in both apps; 360px viewport run asserting no horizontal overflow and capturing CLS. Keyboard checklist executed manually per app against a fixed flow list (login, browse challenges, open challenge, submit flag, scoreboard paging) and recorded as pass/fail.
+**Test scenarios:** interaction script fails loudly if a selector is missing (no silent zero measurements); 360px check flags overflow when introduced deliberately (spot-verify once).
+**Verification:** R3 table complete for both apps, checklist filled in.
+
+### U5. Results report
+
+**Goal:** The deliverable writeup artifact.
+**Requirements:** all; success criteria.
+**Dependencies:** U2, U3, U4.
+**Files:** `docs/benchmarks/2026-07-web-rewrite-benchmark.md`.
+**Approach:** one table per metric group (R1/R2/R3), methodology section (dataset scale, run counts, throttling, fair-LOC rules), and a plain-language findings summary. Losses and ties reported explicitly per the success criteria.
+**Test scenarios:** Test expectation: none — documentation; verification below.
+**Verification:** every R-ID from the Product Contract appears in the report with a measured value or an explicit "not measured because X".
+
+---
+
+## Verification Contract
+
+- The static-metrics script (shellcheck-clean if `.sh`, oxlint-clean if `.ts`) reproduces the Product Contract baseline LOC numbers.
+- Runtime harness completes end-to-end against both apps with the 1k-team dataset.
+- Report covers every R-ID; no metric silently dropped.
+
+## Definition of Done
+
+`docs/benchmarks/2026-07-web-rewrite-benchmark.md` exists with measured medians for R1–R3 across both apps, methodology documented, and reproducible scripts in `bench/`.
+
+## Outstanding Questions (deferred to implementation)
+
+- Exact solve density in the seed data — affects scoreboard render cost; use seed defaults and record what they were.
+- Whether frame-rate capture uses CDP tracing or rAF sampling — pick whichever is stable in the Playwright version available.


### PR DESCRIPTION
Measures the v1 (`apps/web`) vs v2 (`apps/web-new`) rewrite with a reproducible benchmark suite and publishes the results. Headline numbers, all medians of 5 against the same local API seeded with 1,000 teams / 75 challenges:

| Claim | Result |
|---|---|
| Faster at scale | 36% faster scoreboard time-to-rows (298 vs 463 ms), 3.4x lower TBT, 16-28% smaller transfer per route |
| Leaner codebase | 18% less non-style code (30.1k vs 36.9k fair LOC), half the build time, 35% smaller node_modules |
| Better UX | Interaction-latency parity, no 360px overflow in either app, fuller aria-label coverage in v2 |

Losses are reported plainly: v2's LCP is ~70-80 ms higher on the two lightest routes and its scoreboard JS heap is roughly double (virtualizer state).

- `bench/` holds the harness: fair-LOC/static metrics (`static-metrics.sh`), Lighthouse medians (`lighthouse.sh`), scoreboard stress + interaction probes (Playwright, `stress-scoreboard.ts` / `interactions.ts`), keyboard checklist.
- `apps/seed` gains a `SEED_GENERATED_CHALLENGE_COUNT` env override (mirroring `SEED_TEAM_COUNT`) so the dataset can reach realistic challenge counts.
- Full report: `docs/benchmarks/2026-07-web-rewrite-benchmark.md`; methodology and plan: `docs/plans/2026-07-07-001-chore-web-rewrite-benchmark-plan.md`.

Validation: harnesses were executed end-to-end against both apps (results in the report); `static-metrics.sh` is shellcheck-clean and deterministic across reruns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->