### PR TITLE
feat(k8s-operator): add dns bool

### DIFF
--- a/apps/api/src/providers/instancer/k8s-instancer.ts
+++ b/apps/api/src/providers/instancer/k8s-instancer.ts
@@ -420,6 +420,9 @@ const podSchema = z.object({
   ports: z.array(servicePortSchema).check(z.describe('Ports')),
   spec: podSpecSchema.check(z.describe('Pod spec')),
   egress: z.optional(z.boolean()).check(z.describe('Egress')),
+  dns: z
+    .optional(z.boolean())
+    .check(z.describe('DNS (defaults to the egress value)')),
   labels: z
     .optional(z.record(z.string(), z.string()))
     .check(z.describe('Labels')),

--- a/apps/docs/src/content/docs/integrations/instancer/kubernetes.md
+++ b/apps/docs/src/content/docs/integrations/instancer/kubernetes.md
@@ -219,15 +219,18 @@ Terraform requests the wildcard certificate outside the cluster, so DNS provider
 
 ## Network policies
 
-The controller creates three `NetworkPolicy` resources in every instance namespace:
+The controller creates four `NetworkPolicy` resources in every instance namespace:
 
 | Policy | Pod selector | Behavior |
 | --- | --- | --- |
-| `isolate-namespace` | All pods | Ingress is restricted to other pods in the same managed namespace. Egress is restricted to pods in the same namespace plus UDP `53` to the `kube-system` namespace for DNS. |
+| `isolate-namespace` | All pods | Ingress is restricted to other pods in the same managed namespace. Egress is restricted to pods in the same namespace. |
+| `dns` | `rctf.osec.io/dns=true` | Allows egress on UDP and TCP `53` to the `kube-system` namespace for DNS resolution. |
 | `ingress-traefik` | `rctf.osec.io/exposed=true` | Allows ingress from Traefik pods in the `traefik` namespace. Applied only to pods that match an `<red>expose[].containerName</red>` entry. |
 | `egress` | `rctf.osec.io/egress=true` | Allows egress to `0.0.0.0/0` except RFC1918 (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), CGNAT (`100.64.0.0/10`), and link-local (`169.254.0.0/16`). |
 
 The controller labels a pod as exposed when it appears in an `<red>expose[]</red>` entry. It adds the egress label only when that pod sets `egress: true{:yml}` in `<red>instancerConfig</red>`. Leave it `false{:yml}` when the challenge does not need internet access.
+
+The dns label follows the pod's `dns{:yml}` field. When `dns{:yml}` is unset, it defaults to the `egress{:yml}` value, so pods with internet access resolve names without extra configuration. An isolated pod gets no DNS unless it opts in with `dns: true{:yml}`.
 
 :::note[Cluster network plugin]
 Network policies only enforce isolation when the cluster's CNI supports them. The bundled GKE Terraform module enables GKE Dataplane V2, which enforces them. On a bare-metal cluster, make sure the chosen CNI honors `NetworkPolicy`.
@@ -399,7 +402,7 @@ deployment:
 
 Things worth pointing at in this example:
 
-- **`egress: false{:yml}`** keeps the pod sealed off from public internet egress. Set it to `true{:yml}` only for challenges that need outbound access.
+- **`egress: false{:yml}`** keeps the pod sealed off from public internet egress and, since `dns{:yml}` is unset, from DNS as well. Set it to `true{:yml}` only for challenges that need outbound access, or set `dns: true{:yml}` alone when a pod only needs name resolution.
 - **Resource `<red>requests</red>` and `<red>limits</red>`** keep one instance from starving the node. Set both from the expected peak load for one team.
 - **`<red>readinessProbe</red>`** keeps Traefik from routing to the pod before the app is up. Without it, the first request after creation often 502s while the container is still booting.
 - **`<red>readOnlyRootFilesystem</red>` plus the sized `<red>emptyDir</red>`** gives the app a bounded writable `/tmp/{:dir}` without letting it write into the image layer.

--- a/apps/k8s-operator/api/v1/challengeinstance_types.go
+++ b/apps/k8s-operator/api/v1/challengeinstance_types.go
@@ -74,6 +74,9 @@ type ChallengeInstancePod struct {
 	Egress bool `json:"egress"`
 
 	// +optional
+	Dns *bool `json:"dns"`
+
+	// +optional
 	Labels map[string]string `json:"labels"`
 }
 

--- a/apps/k8s-operator/api/v1/zz_generated.deepcopy.go
+++ b/apps/k8s-operator/api/v1/zz_generated.deepcopy.go
@@ -121,6 +121,11 @@ func (in *ChallengeInstancePod) DeepCopyInto(out *ChallengeInstancePod) {
 		}
 	}
 	in.Spec.DeepCopyInto(&out.Spec)
+	if in.Dns != nil {
+		in, out := &in.Dns, &out.Dns
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))

--- a/apps/k8s-operator/config/crd/bases/rctf.osec.io_challengeinstances.yaml
+++ b/apps/k8s-operator/config/crd/bases/rctf.osec.io_challengeinstances.yaml
@@ -68,6 +68,8 @@ spec:
               pods:
                 items:
                   properties:
+                    dns:
+                      type: boolean
                     egress:
                       type: boolean
                     labels:

--- a/apps/k8s-operator/dist/install.yaml
+++ b/apps/k8s-operator/dist/install.yaml
@@ -76,6 +76,8 @@ spec:
               pods:
                 items:
                   properties:
+                    dns:
+                      type: boolean
                     egress:
                       type: boolean
                     labels:

--- a/apps/k8s-operator/internal/controller/challengeinstance_controller.go
+++ b/apps/k8s-operator/internal/controller/challengeinstance_controller.go
@@ -58,6 +58,7 @@ const (
 	labelChallengeId            = "rctf.osec.io/challenge-id"
 	labelPod                    = "rctf.osec.io/pod"
 	labelEgress                 = "rctf.osec.io/egress"
+	labelDns                    = "rctf.osec.io/dns"
 	labelExposed                = "rctf.osec.io/exposed"
 	annotationExposedHostnames  = "rctf.osec.io/exposed-hostnames"
 	managedBy                   = "rctf-operator"
@@ -381,7 +382,7 @@ func (r *ChallengeInstanceReconciler) EnsureNetworkPolicies(ctx context.Context,
 	tcp := corev1.ProtocolTCP
 	dnsPort := intstr.FromInt32(int32(53))
 	for _, networkPolicy := range []networkingv1.NetworkPolicy{
-		// Restrict network traffic only to inside the instance's namespace (except for kube-dns)
+		// Restrict network traffic only to inside the instance's namespace
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespaceName,
@@ -424,6 +425,23 @@ func (r *ChallengeInstanceReconciler) EnsureNetworkPolicies(ctx context.Context,
 							},
 						},
 					},
+				},
+			},
+		},
+		// optionally enabled DNS for individual pods
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespaceName,
+				Name:      "dns",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						labelDns: "true",
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
 					{
 						To: []networkingv1.NetworkPolicyPeer{
 							{
@@ -586,6 +604,16 @@ func (r *ChallengeInstanceReconciler) EnsureDeployments(ctx context.Context, ins
 			egress = "true"
 		}
 
+		// enable dns if egress is enabled and dns is unset
+		dnsEnabled := pod.Egress
+		if pod.Dns != nil {
+			dnsEnabled = *pod.Dns
+		}
+		dns := "false"
+		if dnsEnabled {
+			dns = "true"
+		}
+
 		exposed := "false"
 		for _, expose := range instance.Spec.Expose {
 			if expose.ContainerName != pod.Name {
@@ -602,6 +630,7 @@ func (r *ChallengeInstanceReconciler) EnsureDeployments(ctx context.Context, ins
 		podLabels[labelChallengeId] = instance.Spec.ChallengeId
 		podLabels[labelPod] = pod.Name
 		podLabels[labelEgress] = egress
+		podLabels[labelDns] = dns
 		podLabels[labelExposed] = exposed
 
 		// having secure defaults is nice


### PR DESCRIPTION
originally reported by nebula sec vega `finding_90beecc3212f6dd0436476c789c77199`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->