### PR TITLE
fix(api): reject banned teams in ext auth

### DIFF
--- a/apps/api/src/routes/v2/users/routes/get-user-self.ts
+++ b/apps/api/src/routes/v2/users/routes/get-user-self.ts
@@ -19,6 +19,7 @@ usersGroup.route(GetUserSelfRouteV2, async ({ ctx, user, res }) => {
     teamToken: teamToken,
     allowedDivisions: allowedDivs,
     perms: user.perms,
+    banned: fullUser.banned ?? false,
     avatarUrl: fullUser.avatarUrl ?? null,
     countryCode: fullUser.countryCode ?? null,
     statusText: fullUser.statusText ?? null,

--- a/apps/docs/src/content/docs/admin/external-auth.md
+++ b/apps/docs/src/content/docs/admin/external-auth.md
@@ -43,7 +43,7 @@ This public endpoint returns `<green>goodExternalAuthClient</green>` with the ap
 
 ### `<route>POST /api/v2/external-auth/authorize</route>`
 
-Send `<red>{clientId, redirectUri, state?}</red>` with the user's session token in `Authorization: Bearer`. The response contains `<red>{redirectTo}</red>`, the complete callback URL with `code` and the optional `state`.
+Send `<red>{clientId, redirectUri, state?}</red>` with the user's session token in `Authorization: Bearer`. The response contains `<red>{redirectTo}</red>`, the complete callback URL with `code` and the optional `state`. Banned teams receive `<green>badPerms</green>` with HTTP 403 and cannot complete the flow.
 
 ### `<route>POST /api/v2/external-auth/token</route>`
 
@@ -92,13 +92,16 @@ export async function exchangeCode(code: string): Promise<{ accessToken: string 
   return { accessToken: body.data.accessToken }
 }
 
-// 3. Identify the team
+// 3. Identify the team and reject banned teams
 export async function fetchTeam(accessToken: string): Promise<{ id: string; name: string }> {
-  const res = await fetch(`${RCTF_BASE_URL}/api/v1/users/me`, {
+  const res = await fetch(`${RCTF_BASE_URL}/api/v2/users/me`, {
     headers: { Authorization: `Bearer ${accessToken}` },
   })
   const body = (await res.json()) as {
-    data: { id: string; name: string }
+    data: { id: string; name: string; banned: boolean }
+  }
+  if (body.data.banned) {
+    throw new Error('team is banned')
   }
   return body.data
 }

--- a/apps/docs/src/content/docs/api/external-auth/authorize.md
+++ b/apps/docs/src/content/docs/api/external-auth/authorize.md
@@ -26,6 +26,8 @@ Mints a single-use authorization code for the signed-in user and returns the URL
 
 The `<red>redirectUri</red>` must exactly match the URI registered for the client. Wildcards and path normalization are not supported. A mismatch returns `<response>400 badExternalAuthRequest</response>` without revealing whether the client or URI was wrong.
 
+Banned teams cannot mint codes. When the session token belongs to a banned team, the route returns `<response>403 badPerms</response>`.
+
 ::request-body{def="AuthorizeExternalAuthRouteV2" title="Request body"}
 
 ::response-body{def="AuthorizeExternalAuthRouteV2" response="goodExternalAuthAuthorize" title="Response fields"}

--- a/apps/docs/src/content/docs/api/external-auth/index.md
+++ b/apps/docs/src/content/docs/api/external-auth/index.md
@@ -36,11 +36,11 @@ The flow uses familiar OAuth2 field names, including `client_id`, `redirect_uri`
 3. The user logs into rCTF if needed, then approves. The page calls `<route>POST /api/v2/external-auth/authorize</route>` with the user's session token and receives a `<red>redirectTo</red>` URL.
 4. The browser navigates to `<red>redirect_uri</red>?code=...&state=...`.
 5. The external service's backend exchanges the code through `<route>POST /api/v2/external-auth/token</route>` and receives `{accessToken, tokenType: "bearer"}{:ts}`.
-6. The service uses the access token in `Authorization: Bearer ...` against any rCTF endpoint - typically `<route>GET /api/v1/users/me</route>` to identify the team.
+6. The service uses the access token in `Authorization: Bearer ...` against any rCTF endpoint - typically `<route>GET /api/v2/users/me</route>` to identify the team.
 
 ### Failure model
 
-An unknown client, wrong secret, mismatched redirect URI, or invalid code all return `<response>400 badExternalAuthRequest</response>`. The response does not reveal which check failed. `<route>POST /api/v2/external-auth/authorize</route>` also returns `<response>401 badToken</response>` when the user's session token is missing or invalid.
+An unknown client, wrong secret, mismatched redirect URI, or invalid code all return `<response>400 badExternalAuthRequest</response>`. The response does not reveal which check failed. `<route>POST /api/v2/external-auth/authorize</route>` also returns `<response>401 badToken</response>` when the user's session token is missing or invalid, and `<response>403 badPerms</response>` when the team is banned.
 
 ### Code lifetime
 

--- a/packages/types/src/responses/good-user-self-data-v2.ts
+++ b/packages/types/src/responses/good-user-self-data-v2.ts
@@ -70,6 +70,9 @@ export const GoodUserSelfDataV2 = response('goodUserSelfDataV2', {
     perms: example(z.nullable(z.int()), null).check(
       z.describe('Permission bitmask, or `null` for a standard user.')
     ),
+    banned: example(z.boolean(), false).check(
+      z.describe('Whether the team is banned from the competition.')
+    ),
     avatarUrl: example(
       z.nullable(z.string()),
       'https://rctf.osec.io/uploads/avatar.png'

--- a/packages/types/src/routes/v2/external-auth.ts
+++ b/packages/types/src/routes/v2/external-auth.ts
@@ -3,6 +3,7 @@ import { defineRoute } from '../../internal'
 import {
   BadBody,
   BadExternalAuthRequest,
+  BadPerms,
   BadToken,
   GoodExternalAuthAuthorize,
   GoodExternalAuthClient,
@@ -27,8 +28,9 @@ export const AuthorizeExternalAuthRouteV2 = defineRoute({
   path: '/v2/external-auth/authorize',
   method: 'POST',
   goodResponses: [GoodExternalAuthAuthorize],
-  badResponses: [BadBody, BadExternalAuthRequest, BadToken],
+  badResponses: [BadBody, BadExternalAuthRequest, BadPerms, BadToken],
   authRequired: true,
+  rejectBanned: true,
   body: z.object({
     clientId: z.string().check(z.describe('Public client ID.')),
     redirectUri: HttpUrl.check(

--- a/tests/server/tests/integration/external-auth.test.ts
+++ b/tests/server/tests/integration/external-auth.test.ts
@@ -1,5 +1,5 @@
 import { config } from '@rctf/config'
-import { createDatabase, externalAuthClients } from '@rctf/db'
+import { createDatabase, externalAuthClients, users } from '@rctf/db'
 import {
   BadExternalAuthRequest,
   BadPerms,
@@ -10,11 +10,13 @@ import {
   GoodExternalAuthAuthorize,
   GoodExternalAuthClient,
   GoodExternalAuthToken,
+  GoodUserSelfDataV2,
   Permissions,
 } from '@rctf/types'
 import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import type { Hono } from 'hono'
+import { invalidateUserCache } from '../../../../apps/api/src/cache/auth-cache'
 import { createRedis } from '../../../../apps/api/src/util/redis'
 import { getApp, request } from '../../app'
 import {
@@ -365,6 +367,60 @@ describe('external-auth rejection paths', () => {
       await exchange({ clientId: client.id, clientSecret: secret, code }),
       BadExternalAuthRequest
     )
+  })
+
+  test('banned team cannot authorize -> badPerms', async () => {
+    const { client } = await createClient()
+    const { user } = await generateRealTestUser()
+    await getDb()
+      .update(users)
+      .set({ banned: true })
+      .where(eq(users.id, user.id))
+    const sessionToken = await generateAuthToken(user.id)
+
+    const res = await authorize(sessionToken, {
+      clientId: client.id,
+      redirectUri: client.redirectUri,
+    })
+    await expectResponse(res, BadPerms)
+  })
+
+  test('team banned after exchange is flagged on /v2/users/me', async () => {
+    const { client, secret } = await createClient()
+    const { user } = await generateRealTestUser()
+    const sessionToken = await generateAuthToken(user.id)
+
+    const authRes = await authorize(sessionToken, {
+      clientId: client.id,
+      redirectUri: client.redirectUri,
+    })
+    const code = codeFromRedirectTo(
+      ((await authRes.json()) as { data: { redirectTo: string } }).data
+        .redirectTo
+    )
+    const tokenBody = (await expectResponse(
+      await exchange({ clientId: client.id, clientSecret: secret, code }),
+      GoodExternalAuthToken
+    )) as { data: { accessToken: string } }
+    const headers = { Authorization: `Bearer ${tokenBody.data.accessToken}` }
+
+    const beforeBody = (await expectResponse(
+      await request(app, '/api/v2/users/me', { headers }),
+      GoodUserSelfDataV2
+    )) as { data: { banned: boolean } }
+    expect(beforeBody.data.banned).toBe(false)
+
+    await getDb()
+      .update(users)
+      .set({ banned: true })
+      .where(eq(users.id, user.id))
+    await invalidateUserCache(await createRedis(), user.id)
+
+    const afterBody = (await expectResponse(
+      await request(app, '/api/v2/users/me', { headers }),
+      GoodUserSelfDataV2
+    )) as { data: { banned: boolean } }
+    expect(afterBody.data.banned).toBe(true)
   })
 
   test('authorize requires an authenticated user', async () => {


### PR DESCRIPTION
originally reported by nebula sec vega `finding_2ff04966573879d2f10cdb87507ad15f`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->