### PR TITLE
fix(api): ratelimit extauth

### DIFF
--- a/apps/api/src/routes/v2/external-auth/routes/authorize.ts
+++ b/apps/api/src/routes/v2/external-auth/routes/authorize.ts
@@ -3,6 +3,7 @@ import {
   getExternalAuthClientPublic,
   issueExternalAuthCode,
 } from '../../../../services/external-auth'
+import { rateLimitExternalAuthAuthorize } from '../../../../services/rate-limit'
 import externalAuthGroup from '../group'
 
 externalAuthGroup.route(
@@ -11,6 +12,14 @@ externalAuthGroup.route(
     const client = await getExternalAuthClientPublic(ctx.var.db, body.clientId)
     if (!client || client.redirectUri !== body.redirectUri) {
       return res.badExternalAuthRequest()
+    }
+
+    const timeLeft = await rateLimitExternalAuthAuthorize(
+      ctx.var.redis,
+      user.id
+    )
+    if (timeLeft !== undefined) {
+      return res.badRateLimit({ timeLeft })
     }
 
     const code = await issueExternalAuthCode(ctx.var.redis, {

--- a/apps/api/src/services/rate-limit.ts
+++ b/apps/api/src/services/rate-limit.ts
@@ -57,6 +57,12 @@ export const rateLimitInstancerAction = (
     ttlMilliseconds
   )
 
+// burst 5, 1 per 10s per user
+export const rateLimitExternalAuthAuthorize = (
+  redis: TypedRedis,
+  userId: string
+) => rateLimit(redis, `rl:EXTERNAL_AUTH_AUTHORIZE:${userId}`, 5, 50_000)
+
 // burst 3, 1 per 1s per IP
 export const rateLimitSearch = (redis: TypedRedis, ip: string) =>
   rateLimit(redis, `rl:SEARCH:${ip}`, 3, 3000)

--- a/apps/docs/src/content/docs/api/external-auth/authorize.md
+++ b/apps/docs/src/content/docs/api/external-auth/authorize.md
@@ -28,6 +28,8 @@ The `<red>redirectUri</red>` must exactly match the URI registered for the clien
 
 Banned teams cannot mint codes. When the session token belongs to a banned team, the route returns `<response>403 badPerms</response>`.
 
+Code issuance is rate limited per user with burst `5` and refill window `50000` ms. Exceeding the limit returns `<response>429 badRateLimit</response>` with the wait in `data.timeLeft`.
+
 ::request-body{def="AuthorizeExternalAuthRouteV2" title="Request body"}
 
 ::response-body{def="AuthorizeExternalAuthRouteV2" response="goodExternalAuthAuthorize" title="Response fields"}

--- a/packages/types/src/routes/v2/external-auth.ts
+++ b/packages/types/src/routes/v2/external-auth.ts
@@ -4,6 +4,7 @@ import {
   BadBody,
   BadExternalAuthRequest,
   BadPerms,
+  BadRateLimit,
   BadToken,
   GoodExternalAuthAuthorize,
   GoodExternalAuthClient,
@@ -28,7 +29,13 @@ export const AuthorizeExternalAuthRouteV2 = defineRoute({
   path: '/v2/external-auth/authorize',
   method: 'POST',
   goodResponses: [GoodExternalAuthAuthorize],
-  badResponses: [BadBody, BadExternalAuthRequest, BadPerms, BadToken],
+  badResponses: [
+    BadBody,
+    BadExternalAuthRequest,
+    BadPerms,
+    BadRateLimit,
+    BadToken,
+  ],
   authRequired: true,
   rejectBanned: true,
   body: z.object({

--- a/tests/server/tests/integration/external-auth.test.ts
+++ b/tests/server/tests/integration/external-auth.test.ts
@@ -3,6 +3,7 @@ import { createDatabase, externalAuthClients, users } from '@rctf/db'
 import {
   BadExternalAuthRequest,
   BadPerms,
+  BadRateLimit,
   BadToken,
   GoodAdminExternalAuthClientCreate,
   GoodAdminExternalAuthClientDelete,
@@ -421,6 +422,37 @@ describe('external-auth rejection paths', () => {
       GoodUserSelfDataV2
     )) as { data: { banned: boolean } }
     expect(afterBody.data.banned).toBe(true)
+  })
+
+  test('authorize is rate limited per user -> badRateLimit', async () => {
+    const { client } = await createClient()
+    const { user } = await generateRealTestUser()
+    const sessionToken = await generateAuthToken(user.id)
+
+    for (let i = 0; i < 5; i++) {
+      const res = await authorize(sessionToken, {
+        clientId: client.id,
+        redirectUri: client.redirectUri,
+      })
+      await expectResponse(res, GoodExternalAuthAuthorize)
+    }
+
+    const limited = await authorize(sessionToken, {
+      clientId: client.id,
+      redirectUri: client.redirectUri,
+    })
+    const body = (await expectResponse(limited, BadRateLimit)) as {
+      data: { timeLeft: number }
+    }
+    expect(body.data.timeLeft).toBeGreaterThan(0)
+
+    const otherUser = await generateRealTestUser()
+    const otherToken = await generateAuthToken(otherUser.user.id)
+    const otherRes = await authorize(otherToken, {
+      clientId: client.id,
+      redirectUri: client.redirectUri,
+    })
+    await expectResponse(otherRes, GoodExternalAuthAuthorize)
   })
 
   test('authorize requires an authenticated user', async () => {


### PR DESCRIPTION
originally reported by nebula sec vega `finding_a79482f60ba4125bc947b60339854973`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->