### PR TITLE
fix(api): set proxy trust to 2

### DIFF
--- a/apps/docs/src/content/docs/configuration.md
+++ b/apps/docs/src/content/docs/configuration.md
@@ -467,16 +467,18 @@ See [Moderation Providers](/providers/moderation) for details.
 ```yaml
 proxy:
   cloudflare: true
-  trust: loopback
+  trust: 2
 ```
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `<red>proxy.cloudflare</red>` | `boolean{:ts}` | `false{:ts}` | Trust Cloudflare `CF-Connecting-IP` header for client IP |
-| `<red>proxy.trust</red>` | `boolean{:ts}` \| `string{:ts}` \| `string[]{:ts}` \| `number{:ts}` | `'loopback'{:ts}` | Proxy trust setting for `X-Forwarded-For`. `true{:ts}` trusts all, a number trusts the first N hops, a string or array specifies trusted CIDR ranges or the named subnets `loopback{:ts}`, `linklocal{:ts}`, `uniquelocal{:ts}` |
+| `<red>proxy.trust</red>` | `boolean{:ts}` \| `string{:ts}` \| `string[]{:ts}` \| `number{:ts}` | `2{:ts}` | Proxy trust setting for `X-Forwarded-For`. `true{:ts}` trusts all, a number trusts exactly that many proxy hops in front of the API, a string or array specifies trusted CIDR ranges or the named subnets `loopback{:ts}`, `linklocal{:ts}`, `uniquelocal{:ts}` |
+
+The bundled nginx inside the container counts as the first hop, so the default of `2{:ts}` matches the [standard deployment](/meta/running-a-successful-ctf/setup): the bundled nginx plus one reverse proxy on the host. With it, logs and rate limits use the participant's IP as reported by the host proxy.
 
 :::warning
-Behind Cloudflare, set `<red>proxy.cloudflare</red>` to `true{:ts}` so logs and rate limits use the participant's IP. For any other reverse proxy, configure `<red>proxy.trust</red>` with the proxies rCTF should trust.
+A hop count must match your topology exactly. Setting it too high lets participants spoof `X-Forwarded-For{:http}` to evade per-IP rate limits, while setting it too low attributes all traffic to one of your proxies. Increase it if you add another layer (such as a load balancer), set it to `1{:ts}` if the container is exposed directly, and behind Cloudflare set `<red>proxy.cloudflare</red>` to `true{:ts}` instead.
 :::
 
 ### Blood bot

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -192,7 +192,7 @@ export const ServerConfigSchema = z.object({
       cloudflare: z._default(z.boolean(), false),
       trust: z._default(
         z.union([z.boolean(), z.string(), z.array(z.string()), z.number()]),
-        'loopback'
+        2
       ),
     }),
     {}


### PR DESCRIPTION
originally reported by nebula sec vega `finding_3bf87b48456d0c8fb64eb70528442d4e`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf-new/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->