### PR TITLE
fix(api): dont return adminBotInputs if provider is unconfigured

### DIFF
--- a/apps/api/src/providers/index.ts
+++ b/apps/api/src/providers/index.ts
@@ -55,7 +55,6 @@ export const instancers: Record<string, InstancerProvider> = Object.fromEntries(
     loadProvider(instancerProviders, providerConfig)!,
   ])
 )
-
 export const defaultInstancerName = resolvedInstancers.defaultName
 export const instancerEnabled = Object.keys(instancers).length > 0
 
@@ -97,6 +96,7 @@ export const adminBotProvider = loadProvider(
   adminBotProviders,
   config.adminBot?.provider
 )
+export const adminBotEnabled = adminBotProvider !== undefined
 
 export const analyticsProvider = (() => {
   if (config.analytics?.provider) {

--- a/apps/api/src/routes/v2/challs/routes/get-challenges.ts
+++ b/apps/api/src/routes/v2/challs/routes/get-challenges.ts
@@ -1,5 +1,5 @@
 import { ChallengeScoringKind, GetChallengesRouteV2 } from '@rctf/types'
-import { instancerEnabled } from '../../../../providers'
+import { adminBotEnabled, instancerEnabled } from '../../../../providers'
 import { getChallenges } from '../../../../services/challenges'
 import {
   resolveInstancerActions,
@@ -39,7 +39,9 @@ challsGroup.route(GetChallengesRouteV2, async ({ res, ctx, user }) => {
         instancerActions: instancerConfig
           ? resolveInstancerActions(instancerConfig)
           : [],
-        adminBotInputs: item.data.adminBotConfig?.inputs ?? null,
+        adminBotInputs: adminBotEnabled
+          ? (item.data.adminBotConfig?.inputs ?? null)
+          : null,
         hasFlag: Boolean(item.data.flag),
         scoringKind: item.data.scoring?.kind ?? ChallengeScoringKind.DECAY,
         yourScore: item.myScore,


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->