### PR TITLE
docs(k8s-instancer): use correct caCertificate example

### DIFF
--- a/apps/docs/src/content/docs/integrations/instancer/index.md
+++ b/apps/docs/src/content/docs/integrations/instancer/index.md
@@ -41,10 +41,7 @@ instancers:
     options:
       apiUrl: https://k8s.example.com
       authToken: <service-account-token>
-      caCertificate: |
-        -----BEGIN CERTIFICATE-----
-        ...
-        -----END CERTIFICATE-----
+      caCertificate: <base64-encoded-ca>
 defaultInstancer: docker
 ```
 

--- a/apps/docs/src/content/docs/integrations/instancer/kubernetes.md
+++ b/apps/docs/src/content/docs/integrations/instancer/kubernetes.md
@@ -175,10 +175,7 @@ To use GCP Cloud DNS instead of Cloudflare, comment out the Cloudflare blocks in
        options:
          apiUrl: https://203.0.113.10
          authToken: <rctf_instancer_auth_token>
-         caCertificate: |
-           -----BEGIN CERTIFICATE-----
-           ...
-           -----END CERTIFICATE-----
+         caCertificate: <base64-encoded-ca>
    ```
 
    `<red>caCertificate</red>` is required even when the API server certificate is already trusted by the host.


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->