### PR TITLE
fix(k8s-operator): skip svc creation for pods with 0 ports

### DIFF
--- a/apps/k8s-operator/internal/controller/challengeinstance_controller.go
+++ b/apps/k8s-operator/internal/controller/challengeinstance_controller.go
@@ -438,6 +438,10 @@ func (r *ChallengeInstanceReconciler) deployResources(ctx context.Context, insta
 	}, objectManagerInNamespaces(namespace.Name))
 	var serviceHostAliases []corev1.HostAlias
 	for _, pod := range instance.Spec.Pods {
+		if len(pod.Ports) == 0 {
+			continue
+		}
+
 		service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: namespace.Name}}
 		_, err := ctrl.CreateOrUpdate(ctx, r.Client, service, func() error {
 			service.Labels = map[string]string{


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otter-sec/rctf/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->