### PR TITLE
fix(api): redact sensitive header values in logs

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,6 +22,11 @@ const logger = pino({
   level:
     process.env.LOG_LEVEL ??
     (Bun.env.NODE_ENV === 'production' ? 'info' : 'trace'),
+  redact: [
+    'req.headers.authorization',
+    'req.headers.cookie',
+    'req.headers["proxy-authorization"]',
+  ],
 })
 
 const createApp = () => {


### PR DESCRIPTION
This PR adds log scrubbing in Pino instance of API service, so sensitive headers like `Authorization`, `Cookie`, `Proxy-Authorization` are redacted before being logged.

Reference: https://github.com/pinojs/pino/blob/main/docs/redaction.md

Verification:
- Formatted code with `bun run format:oxc`
- Ran the build locally and tried a couple of requests. Resulting logs:
```
{"level":30,"time":1785240143538,"pid":2947919,"hostname":"flamebox","req":{"url":"/api/v2/integrations/client/config","method":"GET","headers":{"accept":"application/json","accept-encoding":"gzip, deflate, br, zstd","accept-language":"en-US,en;q=0.5","cache-control":"no-cache","connection":"close","cookie":"[Redacted]","host":"127.0.0.1:3000","pragma":"no-cache","referer":"http://localhost:5173/","sec-ch-ua":"\"Not;A=Brand\";v=\"8\", \"Chromium\";v=\"150\", \"Brave\";v=\"150\"","sec-ch-ua-mobile":"?0","sec-ch-ua-platform":"\"macOS\"","sec-fetch-dest":"empty","sec-fetch-mode":"cors","sec-fetch-site":"same-origin","sec-gpc":"1","user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"}},"ip":"127.0.0.1","res":{"status":200,"headers":{"content-type":"application/json"}},"reqId":1,"responseTime":2,"msg":"Request completed"}
│ {"level":30,"time":1785240146608,"pid":2947919,"hostname":"flamebox","req":{"url":"/api/v2/integrations/client/config","method":"GET","headers":{"accept":"application/json","accept-encoding":"gzip, deflate, br, zstd","accept-language":"en-US,en;q=0.5","cache-control":"no-cache","connection":"close","cookie":"[Redacted]","host":"127.0.0.1:3000","pragma":"no-cache","referer":"http://localhost:5173/","sec-ch-ua":"\"Not;A=Brand\";v=\"8\", \"Chromium\";v=\"150\", \"Brave\";v=\"150\"","sec-ch-ua-mobile":"?0","sec-ch-ua-platform":"\"macOS\"","sec-fetch-dest":"empty","sec-fetch-mode":"cors","sec-fetch-site":"same-origin","sec-gpc":"1","user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"}},"ip":"127.0.0.1","res":{"status":200,"headers":{"content-type":"application/json"}},"reqId":2,"responseTime":2,"msg":"Request completed"}
```

Addresses issue #198.