### PR TITLE
fix: redact sensitive submission data from logs

### DIFF
--- a/apps/admin-bot/src/core/logger.ts
+++ b/apps/admin-bot/src/core/logger.ts
@@ -1,5 +1,23 @@
-import { pino } from 'pino'
+import { pino, type DestinationStream } from 'pino'
 
-const root = pino({ level: process.env.LOG_LEVEL ?? 'info' })
+const options = (level: string) => ({
+  level,
+  redact: [
+    'flag',
+    'flags[*].flag',
+    'input.*',
+    'inputs.*',
+    'job.flag',
+    'job.flags[*].flag',
+    'job.inputs.*',
+  ],
+})
+
+export const createRootLogger = (
+  destination?: DestinationStream,
+  level = process.env.LOG_LEVEL ?? 'info'
+) => (destination ? pino(options(level), destination) : pino(options(level)))
+
+const root = createRootLogger()
 
 export const createLogger = (module: string) => root.child({ module })

--- a/apps/admin-bot/src/core/logger.ts
+++ b/apps/admin-bot/src/core/logger.ts
@@ -1,25 +1,23 @@
+import { sensitiveLogPaths } from '@rctf/util'
 import { pino, type DestinationStream } from 'pino'
 
-const options = (level: string) => ({
-  level,
-  redact: [
-    'flag',
-    'submittedFlag',
-    'details.submittedFlag',
-    'flags[*].flag',
-    'input',
-    'inputs',
-    'job.flag',
-    'job.flags[*].flag',
-    'job.inputs',
-  ],
-})
+const redact = [
+  ...sensitiveLogPaths,
+  'job.flag',
+  'job.flags[*].flag',
+  'job.inputs',
+]
 
 export const createRootLogger = (
   destination?: DestinationStream,
   level = process.env.LOG_LEVEL ?? 'info'
-) => (destination ? pino(options(level), destination) : pino(options(level)))
+) => pino({ level, redact }, destination)
 
 const root = createRootLogger()
 
 export const createLogger = (module: string) => root.child({ module })
+
+// Error messages may contain participant data, so expose only the type.
+export const errorSummary = (err: unknown) => ({
+  errorType: err instanceof Error ? err.name : typeof err,
+})

--- a/apps/admin-bot/src/core/logger.ts
+++ b/apps/admin-bot/src/core/logger.ts
@@ -16,8 +16,3 @@ export const createRootLogger = (
 const root = createRootLogger()
 
 export const createLogger = (module: string) => root.child({ module })
-
-// Error messages may contain participant data, so expose only the type.
-export const errorSummary = (err: unknown) => ({
-  errorType: err instanceof Error ? err.name : typeof err,
-})

--- a/apps/admin-bot/src/core/logger.ts
+++ b/apps/admin-bot/src/core/logger.ts
@@ -4,12 +4,14 @@ const options = (level: string) => ({
   level,
   redact: [
     'flag',
+    'submittedFlag',
+    'details.submittedFlag',
     'flags[*].flag',
-    'input.*',
-    'inputs.*',
+    'input',
+    'inputs',
     'job.flag',
     'job.flags[*].flag',
-    'job.inputs.*',
+    'job.inputs',
   ],
 })
 

--- a/apps/admin-bot/src/core/poller.ts
+++ b/apps/admin-bot/src/core/poller.ts
@@ -1,7 +1,7 @@
 import type { Logger } from 'pino'
 import { BrowserManager } from '../browser/manager'
 import type { ChallengeLoader } from './loader'
-import { createLogger } from './logger'
+import { createLogger, errorSummary } from './logger'
 import { BufferedOutputHandler } from './output'
 import type { PlatformClient, PulledJob } from './platform'
 import { handleSubmission } from './runner'
@@ -87,10 +87,7 @@ export const processJob = async (
     output.info('admin-bot', 'finished visiting')
     await platform.completeJob(job.id, output.getOutput())
   } catch (err) {
-    log.error(
-      { errorType: err instanceof Error ? err.name : typeof err },
-      'job failed'
-    )
+    log.error(errorSummary(err), 'job failed')
     if (err instanceof Error && err.message === 'timeout') {
       output.fatal('admin-bot', 'timed out')
     } else {

--- a/apps/admin-bot/src/core/poller.ts
+++ b/apps/admin-bot/src/core/poller.ts
@@ -1,7 +1,7 @@
 import type { Logger } from 'pino'
 import { BrowserManager } from '../browser/manager'
 import type { ChallengeLoader } from './loader'
-import { createLogger, errorSummary } from './logger'
+import { createLogger } from './logger'
 import { BufferedOutputHandler } from './output'
 import type { PlatformClient, PulledJob } from './platform'
 import { handleSubmission } from './runner'
@@ -87,7 +87,7 @@ export const processJob = async (
     output.info('admin-bot', 'finished visiting')
     await platform.completeJob(job.id, output.getOutput())
   } catch (err) {
-    log.error(errorSummary(err), 'job failed')
+    log.error({ err }, 'job failed')
     if (err instanceof Error && err.message === 'timeout') {
       output.fatal('admin-bot', 'timed out')
     } else {

--- a/apps/admin-bot/src/core/poller.ts
+++ b/apps/admin-bot/src/core/poller.ts
@@ -1,3 +1,4 @@
+import type { Logger } from 'pino'
 import { BrowserManager } from '../browser/manager'
 import type { ChallengeLoader } from './loader'
 import { createLogger } from './logger'
@@ -36,9 +37,10 @@ export const processJob = async (
   challenges: ChallengeLoader,
   browserManager: BrowserManager,
   platform: PlatformClient,
-  job: PulledJob
+  job: PulledJob,
+  baseLogger: Logger = logger
 ): Promise<void> => {
-  const log = logger.child({
+  const log = baseLogger.child({
     jobId: job.id,
     challengeId: job.challengeId,
     userId: job.userId,
@@ -85,7 +87,10 @@ export const processJob = async (
     output.info('admin-bot', 'finished visiting')
     await platform.completeJob(job.id, output.getOutput())
   } catch (err) {
-    log.error({ err }, 'job failed')
+    log.error(
+      { errorType: err instanceof Error ? err.name : typeof err },
+      'job failed'
+    )
     if (err instanceof Error && err.message === 'timeout') {
       output.fatal('admin-bot', 'timed out')
     } else {

--- a/apps/admin-bot/src/core/runner.ts
+++ b/apps/admin-bot/src/core/runner.ts
@@ -78,7 +78,10 @@ export const handleSubmission = async (
     if (err instanceof Error && err.message === 'timeout') {
       log.warn('challenge timed out')
     } else {
-      log.error({ err }, 'challenge failed')
+      log.error(
+        { errorType: err instanceof Error ? err.name : typeof err },
+        'challenge failed'
+      )
     }
   } finally {
     try {

--- a/apps/admin-bot/src/core/runner.ts
+++ b/apps/admin-bot/src/core/runner.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { withTimeout } from '@rctf/util'
+import type { Logger } from 'pino'
 import { applyHooks } from '../browser/hooks'
 import { BrowserManager } from '../browser/manager'
 import type { ChallengeContext, JobMetadata } from '../types'
@@ -16,9 +17,14 @@ export const handleSubmission = async (
   browserManager: BrowserManager,
   job: JobMetadata,
   input: Record<string, string>,
-  output: OutputHandler
+  output: OutputHandler,
+  baseLogger: Logger = logger
 ): Promise<void> => {
-  const log = logger.child({ input, job })
+  const log = baseLogger.child({
+    challengeId: job.challengeId,
+    configRevision: job.configRevision,
+    userId: job.userId,
+  })
   const challenge = challenges.get(job.challengeId, job.configRevision)
   if (!challenge) {
     log.error('challenge not found')

--- a/apps/admin-bot/src/core/runner.ts
+++ b/apps/admin-bot/src/core/runner.ts
@@ -8,7 +8,7 @@ import { applyHooks } from '../browser/hooks'
 import { BrowserManager } from '../browser/manager'
 import type { ChallengeContext, JobMetadata } from '../types'
 import type { ChallengeLoader } from './loader'
-import { createLogger } from './logger'
+import { createLogger, errorSummary } from './logger'
 import { OutputHandler } from './output'
 
 const logger = createLogger('runner')
@@ -78,10 +78,7 @@ export const handleSubmission = async (
     if (err instanceof Error && err.message === 'timeout') {
       log.warn('challenge timed out')
     } else {
-      log.error(
-        { errorType: err instanceof Error ? err.name : typeof err },
-        'challenge failed'
-      )
+      log.error(errorSummary(err), 'challenge failed')
     }
   } finally {
     try {

--- a/apps/admin-bot/src/core/runner.ts
+++ b/apps/admin-bot/src/core/runner.ts
@@ -8,7 +8,7 @@ import { applyHooks } from '../browser/hooks'
 import { BrowserManager } from '../browser/manager'
 import type { ChallengeContext, JobMetadata } from '../types'
 import type { ChallengeLoader } from './loader'
-import { createLogger, errorSummary } from './logger'
+import { createLogger } from './logger'
 import { OutputHandler } from './output'
 
 const logger = createLogger('runner')
@@ -78,7 +78,7 @@ export const handleSubmission = async (
     if (err instanceof Error && err.message === 'timeout') {
       log.warn('challenge timed out')
     } else {
-      log.error(errorSummary(err), 'challenge failed')
+      log.error({ err }, 'challenge failed')
     }
   } finally {
     try {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -26,6 +26,16 @@ const logger = pino({
     'req.headers.authorization',
     'req.headers.cookie',
     'req.headers["proxy-authorization"]',
+    'flag',
+    'flags[*].flag',
+    'input.*',
+    'inputs.*',
+    'job.flag',
+    'job.flags[*].flag',
+    'job.inputs.*',
+    'req.body.flag',
+    'req.body.flags[*].flag',
+    'req.body.inputs.*',
   ],
 })
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,8 @@ import { withTimeout } from '@rctf/util'
 import { Hono, type MiddlewareHandler } from 'hono'
 import { pinoLogger } from 'hono-pino'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
-import pino from 'pino'
 import type { AppEnv } from './lib/app-env'
+import { createApiLogger } from './lib/logger'
 import { runMigrationsOnStartup } from './lib/migrations'
 import { appEnvMiddleware } from './middlewares/app-env'
 import { dynamicChallengeAuthMiddleware } from './middlewares/dynamic-challenge-auth'
@@ -18,26 +18,7 @@ import { routeModules } from './routes'
 import { analyticsScriptHandler } from './routes/v2/integrations/routes/get-analytics-script'
 import { startLeaderboardWorker, stopWorkers } from './workers'
 
-const logger = pino({
-  level:
-    process.env.LOG_LEVEL ??
-    (Bun.env.NODE_ENV === 'production' ? 'info' : 'trace'),
-  redact: [
-    'req.headers.authorization',
-    'req.headers.cookie',
-    'req.headers["proxy-authorization"]',
-    'flag',
-    'flags[*].flag',
-    'input.*',
-    'inputs.*',
-    'job.flag',
-    'job.flags[*].flag',
-    'job.inputs.*',
-    'req.body.flag',
-    'req.body.flags[*].flag',
-    'req.body.inputs.*',
-  ],
-})
+const logger = createApiLogger()
 
 const createApp = () => {
   const app = new Hono<AppEnv>()

--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -1,3 +1,4 @@
+import { sensitiveLogPaths } from '@rctf/util'
 import { DrizzleQueryError } from 'drizzle-orm'
 import pino, { type DestinationStream } from 'pino'
 
@@ -5,20 +6,8 @@ const redact = [
   'req.headers.authorization',
   'req.headers.cookie',
   'req.headers["proxy-authorization"]',
-  'flag',
-  'submittedFlag',
-  'details.submittedFlag',
-  'flags[*].flag',
-  'input',
-  'inputs',
-  'job.flag',
-  'job.flags[*].flag',
-  'job.inputs',
-  'req.body.flag',
-  'req.body.submittedFlag',
-  'req.body.flags[*].flag',
-  'req.body.input',
-  'req.body.inputs',
+  ...sensitiveLogPaths,
+  // backstop for non-Error values logged under err/error, which skip the serializer
   'err.query',
   'err.params',
   'error.query',
@@ -35,21 +24,20 @@ type QueryError = Error & {
   }
 }
 
-const isQueryError = (error: unknown): error is QueryError =>
+const isQueryError = (error: Error): error is QueryError =>
   error instanceof DrizzleQueryError ||
-  (error instanceof Error &&
-    typeof (error as Partial<QueryError>).query === 'string' &&
+  (typeof (error as Partial<QueryError>).query === 'string' &&
     Array.isArray((error as Partial<QueryError>).params))
 
-const findQueryError = (error: unknown): QueryError | undefined => {
+const findQueryError = (error: Error): QueryError | undefined => {
   const seen = new Set<Error>()
-  let current = error
+  let current: unknown = error
   while (current instanceof Error && !seen.has(current)) {
     if (isQueryError(current)) {
       return current
     }
     seen.add(current)
-    current = (current as Error & { cause?: unknown }).cause
+    current = current.cause
   }
   return undefined
 }
@@ -65,33 +53,37 @@ const sanitizedStack = (error: Error): string | undefined => {
   return frames ? `${error.name}: Database query failed\n${frames}` : undefined
 }
 
+// Query errors embed bound parameters (flags, inputs) in message/query/params,
+// so replace them with a sanitized summary. Everything else passes through.
 const serializeError = (error: unknown) => {
-  const queryError = findQueryError(error)
-  if (!queryError) {
+  if (!(error instanceof Error)) {
     return pino.stdSerializers.err(error as Error)
   }
-
-  const code = stringProperty(queryError.cause?.code)
-  const constraint = stringProperty(
-    queryError.cause?.constraint_name ?? queryError.cause?.constraint
-  )
+  const queryError = findQueryError(error)
+  if (!queryError) {
+    return pino.stdSerializers.err(error)
+  }
   return {
     type: 'DrizzleQueryError',
     message: 'Database query failed',
-    stack: sanitizedStack(error instanceof Error ? error : queryError),
-    ...(code ? { code } : {}),
-    ...(constraint ? { constraint } : {}),
+    stack: sanitizedStack(error),
+    code: stringProperty(queryError.cause?.code),
+    constraint: stringProperty(
+      queryError.cause?.constraint_name ?? queryError.cause?.constraint
+    ),
   }
 }
-
-const options = (level: string) => ({
-  level,
-  redact,
-  serializers: { err: serializeError, error: serializeError },
-})
 
 export const createApiLogger = (
   destination?: DestinationStream,
   level = process.env.LOG_LEVEL ??
     (Bun.env.NODE_ENV === 'production' ? 'info' : 'trace')
-) => (destination ? pino(options(level), destination) : pino(options(level)))
+) =>
+  pino(
+    {
+      level,
+      redact,
+      serializers: { err: serializeError, error: serializeError },
+    },
+    destination
+  )

--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -50,11 +50,13 @@ const sanitizedStack = (error: Error): string | undefined => {
     ?.split('\n')
     .filter(line => /^\s+at\s/.test(line))
     .join('\n')
-  return frames ? `${error.name}: Database query failed\n${frames}` : undefined
+  return frames
+    ? `DrizzleQueryError: Failed query (parameters redacted)\n${frames}`
+    : undefined
 }
 
-// Query errors embed bound parameters (flags, inputs) in message/query/params,
-// so replace them with a sanitized summary. Everything else passes through.
+// Query errors embed bound parameters (flags, inputs) in message and params.
+// Keep the parameterized query for diagnostics without logging those values.
 const serializeError = (error: unknown) => {
   if (!(error instanceof Error)) {
     return pino.stdSerializers.err(error as Error)
@@ -65,7 +67,7 @@ const serializeError = (error: unknown) => {
   }
   return {
     type: 'DrizzleQueryError',
-    message: 'Database query failed',
+    message: `Failed query: ${queryError.query}`,
     stack: sanitizedStack(error),
     code: stringProperty(queryError.cause?.code),
     constraint: stringProperty(

--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -41,6 +41,19 @@ const isQueryError = (error: unknown): error is QueryError =>
     typeof (error as Partial<QueryError>).query === 'string' &&
     Array.isArray((error as Partial<QueryError>).params))
 
+const findQueryError = (error: unknown): QueryError | undefined => {
+  const seen = new Set<Error>()
+  let current = error
+  while (current instanceof Error && !seen.has(current)) {
+    if (isQueryError(current)) {
+      return current
+    }
+    seen.add(current)
+    current = (current as Error & { cause?: unknown }).cause
+  }
+  return undefined
+}
+
 const stringProperty = (value: unknown): string | undefined =>
   typeof value === 'string' ? value : undefined
 
@@ -53,18 +66,19 @@ const sanitizedStack = (error: Error): string | undefined => {
 }
 
 const serializeError = (error: unknown) => {
-  if (!isQueryError(error)) {
+  const queryError = findQueryError(error)
+  if (!queryError) {
     return pino.stdSerializers.err(error as Error)
   }
 
-  const code = stringProperty(error.cause?.code)
+  const code = stringProperty(queryError.cause?.code)
   const constraint = stringProperty(
-    error.cause?.constraint_name ?? error.cause?.constraint
+    queryError.cause?.constraint_name ?? queryError.cause?.constraint
   )
   return {
     type: 'DrizzleQueryError',
     message: 'Database query failed',
-    stack: sanitizedStack(error),
+    stack: sanitizedStack(error instanceof Error ? error : queryError),
     ...(code ? { code } : {}),
     ...(constraint ? { constraint } : {}),
   }

--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -1,0 +1,83 @@
+import { DrizzleQueryError } from 'drizzle-orm'
+import pino, { type DestinationStream } from 'pino'
+
+const redact = [
+  'req.headers.authorization',
+  'req.headers.cookie',
+  'req.headers["proxy-authorization"]',
+  'flag',
+  'submittedFlag',
+  'details.submittedFlag',
+  'flags[*].flag',
+  'input',
+  'inputs',
+  'job.flag',
+  'job.flags[*].flag',
+  'job.inputs',
+  'req.body.flag',
+  'req.body.submittedFlag',
+  'req.body.flags[*].flag',
+  'req.body.input',
+  'req.body.inputs',
+  'err.query',
+  'err.params',
+  'error.query',
+  'error.params',
+]
+
+type QueryError = Error & {
+  query: string
+  params: unknown[]
+  cause?: Error & {
+    code?: unknown
+    constraint?: unknown
+    constraint_name?: unknown
+  }
+}
+
+const isQueryError = (error: unknown): error is QueryError =>
+  error instanceof DrizzleQueryError ||
+  (error instanceof Error &&
+    typeof (error as Partial<QueryError>).query === 'string' &&
+    Array.isArray((error as Partial<QueryError>).params))
+
+const stringProperty = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined
+
+const sanitizedStack = (error: Error): string | undefined => {
+  const frames = error.stack
+    ?.split('\n')
+    .filter(line => /^\s+at\s/.test(line))
+    .join('\n')
+  return frames ? `${error.name}: Database query failed\n${frames}` : undefined
+}
+
+const serializeError = (error: unknown) => {
+  if (!isQueryError(error)) {
+    return pino.stdSerializers.err(error as Error)
+  }
+
+  const code = stringProperty(error.cause?.code)
+  const constraint = stringProperty(
+    error.cause?.constraint_name ?? error.cause?.constraint
+  )
+  return {
+    type: 'DrizzleQueryError',
+    message: 'Database query failed',
+    stack: sanitizedStack(error),
+    ...(code ? { code } : {}),
+    ...(constraint ? { constraint } : {}),
+  }
+}
+
+const options = (level: string) => ({
+  level,
+  redact,
+  serializers: { err: serializeError, error: serializeError },
+})
+
+export const createApiLogger = (
+  destination?: DestinationStream,
+  level = process.env.LOG_LEVEL ??
+    (Bun.env.NODE_ENV === 'production' ? 'info' : 'trace')
+) => (destination ? pino(options(level), destination) : pino(options(level)))

--- a/apps/api/src/services/challenges.ts
+++ b/apps/api/src/services/challenges.ts
@@ -1203,7 +1203,6 @@ export const submitFlag = async (
       {
         user: params.userId,
         chall: challenge.id,
-        flag: params.flag,
         cheatedFrom,
       },
       'valid flag for another team; possible flag sharing'
@@ -1214,10 +1213,9 @@ export const submitFlag = async (
     {
       user: params.userId,
       chall: challenge.id,
-      flag: params.flag,
       matchedFlagIndex: matched.index,
     },
-    'successfull flag submission'
+    'successful flag submission'
   )
 
   let bloodNumber: number | null

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,3 +1,4 @@
 export * from './countries'
+export * from './logging'
 export * from './promise'
 export * from './time'

--- a/packages/util/src/logging.ts
+++ b/packages/util/src/logging.ts
@@ -1,0 +1,9 @@
+// Shared so API and admin-bot redaction stay aligned.
+export const sensitiveLogPaths = [
+  'flag',
+  'submittedFlag',
+  'details.submittedFlag',
+  'flags[*].flag',
+  'input',
+  'inputs',
+]

--- a/tests/admin-bot/tests/integration/poller.test.ts
+++ b/tests/admin-bot/tests/integration/poller.test.ts
@@ -1,4 +1,3 @@
-import { Writable } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { BrowserManager } from '../../../../apps/admin-bot/src/browser/manager'
 import { ChallengeLoader } from '../../../../apps/admin-bot/src/core/loader'
@@ -9,6 +8,7 @@ import {
   ensureChallengeLoaded,
   processJob,
 } from '../../../../apps/admin-bot/src/core/poller'
+import { collectStream } from '../../../util'
 
 const browsers = ['chrome', 'firefox'] as const
 const validChallengeSource = (browser: 'chrome' | 'firefox') => `
@@ -241,13 +241,7 @@ for (const browser of browsers) {
         })
       `
       await challenges.loadFromSource('chal-1', 'rev-1', errorSource)
-      let logOutput = ''
-      const destination = new Writable({
-        write(chunk, _encoding, callback) {
-          logOutput += chunk.toString()
-          callback()
-        },
-      })
+      const { destination, read } = collectStream()
       const testLogger = createRootLogger(destination, 'info')
       await processJob(
         challenges,
@@ -256,7 +250,7 @@ for (const browser of browsers) {
         makeJob({ inputs: { url: secretInput } }),
         testLogger
       )
-      await new Promise<void>(resolve => destination.end(resolve))
+      const logOutput = await read()
 
       expect(failedJobs.length).toBe(1)
       expect(failedJobs[0]!.logs).toContain('hit internal server error')

--- a/tests/admin-bot/tests/integration/poller.test.ts
+++ b/tests/admin-bot/tests/integration/poller.test.ts
@@ -222,7 +222,7 @@ for (const browser of browsers) {
     })
 
     test('non-timeout error -> failJob with internal server error', async () => {
-      const secretInput = 'https://example.com/?token=poller-error-secret'
+      const submittedInput = 'https://example.com/?token=poller-error-input'
       const errorSource = `
         const { Challenge } = require('../types')
         export const challenge = new Challenge({
@@ -247,7 +247,7 @@ for (const browser of browsers) {
         challenges,
         browserManager,
         platform,
-        makeJob({ inputs: { url: secretInput } }),
+        makeJob({ inputs: { url: submittedInput } }),
         testLogger
       )
       const logOutput = await read()
@@ -256,7 +256,7 @@ for (const browser of browsers) {
       expect(failedJobs[0]!.logs).toContain('hit internal server error')
       expect(completedJobs.length).toBe(0)
       expect(logOutput).toContain('job failed')
-      expect(logOutput).not.toContain(secretInput)
+      expect(logOutput).toContain(`something broke at ${submittedInput}`)
     })
   })
 }

--- a/tests/admin-bot/tests/integration/poller.test.ts
+++ b/tests/admin-bot/tests/integration/poller.test.ts
@@ -1,6 +1,8 @@
+import { Writable } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { BrowserManager } from '../../../../apps/admin-bot/src/browser/manager'
 import { ChallengeLoader } from '../../../../apps/admin-bot/src/core/loader'
+import { createRootLogger } from '../../../../apps/admin-bot/src/core/logger'
 import { PlatformClient } from '../../../../apps/admin-bot/src/core/platform'
 import type { PulledJob } from '../../../../apps/admin-bot/src/core/platform'
 import {
@@ -239,19 +241,14 @@ for (const browser of browsers) {
         })
       `
       await challenges.loadFromSource('chal-1', 'rev-1', errorSource)
-      const logEntries: unknown[] = []
-      const testLogger = {
-        child(value: unknown) {
-          logEntries.push(value)
-          return this
+      let logOutput = ''
+      const destination = new Writable({
+        write(chunk, _encoding, callback) {
+          logOutput += chunk.toString()
+          callback()
         },
-        error(...args: unknown[]) {
-          logEntries.push(args)
-        },
-        info(...args: unknown[]) {
-          logEntries.push(args)
-        },
-      } as unknown as Parameters<typeof processJob>[4]
+      })
+      const testLogger = createRootLogger(destination, 'info')
       await processJob(
         challenges,
         browserManager,
@@ -259,11 +256,13 @@ for (const browser of browsers) {
         makeJob({ inputs: { url: secretInput } }),
         testLogger
       )
+      await new Promise<void>(resolve => destination.end(resolve))
 
       expect(failedJobs.length).toBe(1)
       expect(failedJobs[0]!.logs).toContain('hit internal server error')
       expect(completedJobs.length).toBe(0)
-      expect(JSON.stringify(logEntries)).not.toContain(secretInput)
+      expect(logOutput).toContain('job failed')
+      expect(logOutput).not.toContain(secretInput)
     })
   })
 }

--- a/tests/admin-bot/tests/integration/poller.test.ts
+++ b/tests/admin-bot/tests/integration/poller.test.ts
@@ -220,6 +220,7 @@ for (const browser of browsers) {
     })
 
     test('non-timeout error -> failJob with internal server error', async () => {
+      const secretInput = 'https://example.com/?token=poller-error-secret'
       const errorSource = `
         const { Challenge } = require('../types')
         export const challenge = new Challenge({
@@ -227,7 +228,7 @@ for (const browser of browsers) {
           inputs: { url: { pattern: '^https?://.*' } },
           browser: '${browser}',
           handler: async (ctx) => {
-            throw new Error('something broke')
+            throw new Error('something broke at ' + ctx.input.url)
           },
           hooksConfig: {
             showConsoleLogs: false,
@@ -238,11 +239,31 @@ for (const browser of browsers) {
         })
       `
       await challenges.loadFromSource('chal-1', 'rev-1', errorSource)
-      await processJob(challenges, browserManager, platform, makeJob())
+      const logEntries: unknown[] = []
+      const testLogger = {
+        child(value: unknown) {
+          logEntries.push(value)
+          return this
+        },
+        error(...args: unknown[]) {
+          logEntries.push(args)
+        },
+        info(...args: unknown[]) {
+          logEntries.push(args)
+        },
+      } as unknown as Parameters<typeof processJob>[4]
+      await processJob(
+        challenges,
+        browserManager,
+        platform,
+        makeJob({ inputs: { url: secretInput } }),
+        testLogger
+      )
 
       expect(failedJobs.length).toBe(1)
       expect(failedJobs[0]!.logs).toContain('hit internal server error')
       expect(completedJobs.length).toBe(0)
+      expect(JSON.stringify(logEntries)).not.toContain(secretInput)
     })
   })
 }

--- a/tests/admin-bot/tests/integration/runner.test.ts
+++ b/tests/admin-bot/tests/integration/runner.test.ts
@@ -154,7 +154,7 @@ for (const browser of browsers) {
     })
 
     test('cleanup runs even on handler error', async () => {
-      const secretInput = 'https://example.com/?token=handler-error-secret'
+      const submittedInput = 'https://example.com/?token=handler-error-input'
       const errorSource = `
         const { Challenge } = require('../types')
         export const challenge = new Challenge({
@@ -182,7 +182,7 @@ for (const browser of browsers) {
           challenges,
           browserManager,
           makeJobMeta(),
-          { url: secretInput },
+          { url: submittedInput },
           output,
           testLogger
         )
@@ -192,12 +192,12 @@ for (const browser of browsers) {
       const logOutput = await read()
 
       expect(thrownError).toBeInstanceOf(Error)
-      expect(thrownError!.message).toBe(`handler failure at ${secretInput}`)
+      expect(thrownError!.message).toBe(`handler failure at ${submittedInput}`)
       // The function should have still run browser setup (verifiable via output)
       const logs = output.getOutput()
       expect(logs).toContain('setting up browser')
       expect(logOutput).toContain('challenge failed')
-      expect(logOutput).not.toContain(secretInput)
+      expect(logOutput).toContain(`handler failure at ${submittedInput}`)
     })
   })
 }

--- a/tests/admin-bot/tests/integration/runner.test.ts
+++ b/tests/admin-bot/tests/integration/runner.test.ts
@@ -34,6 +34,43 @@ const makeJobMeta = (): JobMetadata => ({
   instancerInstances: [],
 })
 
+test('does not bind participant inputs or flags to runner logs', async () => {
+  const bindings: unknown[] = []
+  const testLogger = {
+    child(value: unknown) {
+      bindings.push(value)
+      return this
+    },
+    error() {},
+  } as unknown as Parameters<typeof handleSubmission>[5]
+  const secretFlag = 'flag{runner-log-secret}'
+  const secretInput = 'https://example.com/?token=participant-secret'
+  const job = {
+    ...makeJobMeta(),
+    flag: secretFlag,
+    flags: [{ provider: 'flags/static', flag: secretFlag }],
+  }
+
+  await handleSubmission(
+    new ChallengeLoader(),
+    new BrowserManager(),
+    job,
+    { url: secretInput },
+    new BufferedOutputHandler(64),
+    testLogger
+  )
+
+  expect(bindings).toEqual([
+    {
+      challengeId: job.challengeId,
+      configRevision: job.configRevision,
+      userId: job.userId,
+    },
+  ])
+  expect(JSON.stringify(bindings)).not.toContain(secretFlag)
+  expect(JSON.stringify(bindings)).not.toContain(secretInput)
+})
+
 for (const browser of browsers) {
   describe(`handleSubmission [${browser}]`, () => {
     let challenges: ChallengeLoader

--- a/tests/admin-bot/tests/integration/runner.test.ts
+++ b/tests/admin-bot/tests/integration/runner.test.ts
@@ -1,6 +1,8 @@
+import { Writable } from 'node:stream'
 import { beforeEach, describe, expect, test } from 'bun:test'
 import { BrowserManager } from '../../../../apps/admin-bot/src/browser/manager'
 import { ChallengeLoader } from '../../../../apps/admin-bot/src/core/loader'
+import { createRootLogger } from '../../../../apps/admin-bot/src/core/logger'
 import { BufferedOutputHandler } from '../../../../apps/admin-bot/src/core/output'
 import { handleSubmission } from '../../../../apps/admin-bot/src/core/runner'
 import type { JobMetadata } from '../../../../apps/admin-bot/src/types'
@@ -180,25 +182,14 @@ for (const browser of browsers) {
         })
       `
       await challenges.loadFromSource('chal-1', 'rev-1', errorSource)
-      const logEntries: unknown[] = []
-      const testLogger = {
-        child(value: unknown) {
-          logEntries.push(value)
-          return this
+      let logOutput = ''
+      const destination = new Writable({
+        write(chunk, _encoding, callback) {
+          logOutput += chunk.toString()
+          callback()
         },
-        debug(...args: unknown[]) {
-          logEntries.push(args)
-        },
-        error(...args: unknown[]) {
-          logEntries.push(args)
-        },
-        info(...args: unknown[]) {
-          logEntries.push(args)
-        },
-        warn(...args: unknown[]) {
-          logEntries.push(args)
-        },
-      } as unknown as Parameters<typeof handleSubmission>[5]
+      })
+      const testLogger = createRootLogger(destination, 'info')
 
       let thrownError: Error | undefined
       try {
@@ -213,13 +204,15 @@ for (const browser of browsers) {
       } catch (err) {
         thrownError = err as Error
       }
+      await new Promise<void>(resolve => destination.end(resolve))
 
       expect(thrownError).toBeInstanceOf(Error)
       expect(thrownError!.message).toBe(`handler failure at ${secretInput}`)
       // The function should have still run browser setup (verifiable via output)
       const logs = output.getOutput()
       expect(logs).toContain('setting up browser')
-      expect(JSON.stringify(logEntries)).not.toContain(secretInput)
+      expect(logOutput).toContain('challenge failed')
+      expect(logOutput).not.toContain(secretInput)
     })
   })
 }

--- a/tests/admin-bot/tests/integration/runner.test.ts
+++ b/tests/admin-bot/tests/integration/runner.test.ts
@@ -161,6 +161,7 @@ for (const browser of browsers) {
     })
 
     test('cleanup runs even on handler error', async () => {
+      const secretInput = 'https://example.com/?token=handler-error-secret'
       const errorSource = `
         const { Challenge } = require('../types')
         export const challenge = new Challenge({
@@ -168,7 +169,7 @@ for (const browser of browsers) {
           inputs: { url: { pattern: '^https?://.*' } },
           browser: '${browser}',
           handler: async (ctx) => {
-            throw new Error('handler failure')
+            throw new Error('handler failure at ' + ctx.input.url)
           },
           hooksConfig: {
             showConsoleLogs: false,
@@ -179,6 +180,25 @@ for (const browser of browsers) {
         })
       `
       await challenges.loadFromSource('chal-1', 'rev-1', errorSource)
+      const logEntries: unknown[] = []
+      const testLogger = {
+        child(value: unknown) {
+          logEntries.push(value)
+          return this
+        },
+        debug(...args: unknown[]) {
+          logEntries.push(args)
+        },
+        error(...args: unknown[]) {
+          logEntries.push(args)
+        },
+        info(...args: unknown[]) {
+          logEntries.push(args)
+        },
+        warn(...args: unknown[]) {
+          logEntries.push(args)
+        },
+      } as unknown as Parameters<typeof handleSubmission>[5]
 
       let thrownError: Error | undefined
       try {
@@ -186,18 +206,20 @@ for (const browser of browsers) {
           challenges,
           browserManager,
           makeJobMeta(),
-          { url: 'http://example.com' },
-          output
+          { url: secretInput },
+          output,
+          testLogger
         )
       } catch (err) {
         thrownError = err as Error
       }
 
       expect(thrownError).toBeInstanceOf(Error)
-      expect(thrownError!.message).toBe('handler failure')
+      expect(thrownError!.message).toBe(`handler failure at ${secretInput}`)
       // The function should have still run browser setup (verifiable via output)
       const logs = output.getOutput()
       expect(logs).toContain('setting up browser')
+      expect(JSON.stringify(logEntries)).not.toContain(secretInput)
     })
   })
 }

--- a/tests/admin-bot/tests/integration/runner.test.ts
+++ b/tests/admin-bot/tests/integration/runner.test.ts
@@ -1,4 +1,3 @@
-import { Writable } from 'node:stream'
 import { beforeEach, describe, expect, test } from 'bun:test'
 import { BrowserManager } from '../../../../apps/admin-bot/src/browser/manager'
 import { ChallengeLoader } from '../../../../apps/admin-bot/src/core/loader'
@@ -6,6 +5,7 @@ import { createRootLogger } from '../../../../apps/admin-bot/src/core/logger'
 import { BufferedOutputHandler } from '../../../../apps/admin-bot/src/core/output'
 import { handleSubmission } from '../../../../apps/admin-bot/src/core/runner'
 import type { JobMetadata } from '../../../../apps/admin-bot/src/types'
+import { collectStream } from '../../../util'
 
 const browsers = ['chrome', 'firefox'] as const
 const validChallengeSource = (browser: 'chrome' | 'firefox') => `
@@ -36,15 +36,9 @@ const makeJobMeta = (): JobMetadata => ({
   instancerInstances: [],
 })
 
-test('does not bind participant inputs or flags to runner logs', async () => {
-  const bindings: unknown[] = []
-  const testLogger = {
-    child(value: unknown) {
-      bindings.push(value)
-      return this
-    },
-    error() {},
-  } as unknown as Parameters<typeof handleSubmission>[5]
+test('logs job identifiers but not participant inputs or flags', async () => {
+  const { destination, read } = collectStream()
+  const testLogger = createRootLogger(destination, 'info')
   const secretFlag = 'flag{runner-log-secret}'
   const secretInput = 'https://example.com/?token=participant-secret'
   const job = {
@@ -62,15 +56,12 @@ test('does not bind participant inputs or flags to runner logs', async () => {
     testLogger
   )
 
-  expect(bindings).toEqual([
-    {
-      challengeId: job.challengeId,
-      configRevision: job.configRevision,
-      userId: job.userId,
-    },
-  ])
-  expect(JSON.stringify(bindings)).not.toContain(secretFlag)
-  expect(JSON.stringify(bindings)).not.toContain(secretInput)
+  const logOutput = await read()
+  expect(logOutput).toContain(job.challengeId)
+  expect(logOutput).toContain(job.configRevision)
+  expect(logOutput).toContain(job.userId)
+  expect(logOutput).not.toContain(secretFlag)
+  expect(logOutput).not.toContain(secretInput)
 })
 
 for (const browser of browsers) {
@@ -182,13 +173,7 @@ for (const browser of browsers) {
         })
       `
       await challenges.loadFromSource('chal-1', 'rev-1', errorSource)
-      let logOutput = ''
-      const destination = new Writable({
-        write(chunk, _encoding, callback) {
-          logOutput += chunk.toString()
-          callback()
-        },
-      })
+      const { destination, read } = collectStream()
       const testLogger = createRootLogger(destination, 'info')
 
       let thrownError: Error | undefined
@@ -204,7 +189,7 @@ for (const browser of browsers) {
       } catch (err) {
         thrownError = err as Error
       }
-      await new Promise<void>(resolve => destination.end(resolve))
+      const logOutput = await read()
 
       expect(thrownError).toBeInstanceOf(Error)
       expect(thrownError!.message).toBe(`handler failure at ${secretInput}`)

--- a/tests/admin-bot/tests/unit/logger.test.ts
+++ b/tests/admin-bot/tests/unit/logger.test.ts
@@ -1,15 +1,9 @@
-import { Writable } from 'node:stream'
 import { expect, test } from 'bun:test'
 import { createRootLogger } from '../../../../apps/admin-bot/src/core/logger'
+import { collectStream } from '../../../util'
 
 test('redacts participant inputs and flags from serialized logs', async () => {
-  let output = ''
-  const destination = new Writable({
-    write(chunk, _encoding, callback) {
-      output += chunk.toString()
-      callback()
-    },
-  })
+  const { destination, read } = collectStream()
   const logger = createRootLogger(destination, 'info')
   const secrets = {
     childInput: 'child-input-secret',
@@ -46,7 +40,7 @@ test('redacts participant inputs and flags from serialized logs', async () => {
       'sensitive logging test'
     )
 
-  await new Promise<void>(resolve => destination.end(resolve))
+  const output = await read()
 
   expect(output).toContain('safe-log-marker')
   for (const secret of Object.values(secrets)) {

--- a/tests/admin-bot/tests/unit/logger.test.ts
+++ b/tests/admin-bot/tests/unit/logger.test.ts
@@ -17,6 +17,7 @@ test('redacts participant inputs and flags from serialized logs', async () => {
     topLevelFlag: 'flag{top-level-secret}',
     topLevelInput: 'top-level-input-secret',
     nestedJobFlag: 'flag{nested-job-secret}',
+    submittedFlag: 'flag{submitted-secret}',
   }
 
   logger
@@ -31,8 +32,11 @@ test('redacts participant inputs and flags from serialized logs', async () => {
       {
         marker: 'safe-log-marker',
         flag: secrets.topLevelFlag,
+        submittedFlag: secrets.submittedFlag,
+        details: { submittedFlag: secrets.submittedFlag },
         flags: [{ provider: 'flags/static', flag: secrets.topLevelFlag }],
-        inputs: { url: secrets.topLevelInput },
+        input: secrets.topLevelInput,
+        inputs: secrets.topLevelInput,
         job: {
           flag: secrets.nestedJobFlag,
           flags: [{ provider: 'flags/static', flag: secrets.nestedJobFlag }],

--- a/tests/admin-bot/tests/unit/logger.test.ts
+++ b/tests/admin-bot/tests/unit/logger.test.ts
@@ -1,0 +1,51 @@
+import { Writable } from 'node:stream'
+import { expect, test } from 'bun:test'
+import { createRootLogger } from '../../../../apps/admin-bot/src/core/logger'
+
+test('redacts participant inputs and flags from serialized logs', async () => {
+  let output = ''
+  const destination = new Writable({
+    write(chunk, _encoding, callback) {
+      output += chunk.toString()
+      callback()
+    },
+  })
+  const logger = createRootLogger(destination, 'info')
+  const secrets = {
+    childInput: 'child-input-secret',
+    childFlag: 'flag{child-secret}',
+    topLevelFlag: 'flag{top-level-secret}',
+    topLevelInput: 'top-level-input-secret',
+    nestedJobFlag: 'flag{nested-job-secret}',
+  }
+
+  logger
+    .child({
+      input: { url: secrets.childInput },
+      job: {
+        flag: secrets.childFlag,
+        flags: [{ provider: 'flags/static', flag: secrets.childFlag }],
+      },
+    })
+    .info(
+      {
+        marker: 'safe-log-marker',
+        flag: secrets.topLevelFlag,
+        flags: [{ provider: 'flags/static', flag: secrets.topLevelFlag }],
+        inputs: { url: secrets.topLevelInput },
+        job: {
+          flag: secrets.nestedJobFlag,
+          flags: [{ provider: 'flags/static', flag: secrets.nestedJobFlag }],
+          inputs: { url: secrets.topLevelInput },
+        },
+      },
+      'sensitive logging test'
+    )
+
+  await new Promise<void>(resolve => destination.end(resolve))
+
+  expect(output).toContain('safe-log-marker')
+  for (const secret of Object.values(secrets)) {
+    expect(output).not.toContain(secret)
+  }
+})

--- a/tests/server/tests/integration/sensitive-logging.test.ts
+++ b/tests/server/tests/integration/sensitive-logging.test.ts
@@ -44,6 +44,7 @@ test('does not include submitted flags in successful or cheated logs', async () 
     warn: capture('warn'),
     error: capture('error'),
   } as unknown as PinoLogger
+  // Return the selected response helper name as its response kind.
   const responses = new Proxy(Object.create(null), {
     get: (_target, property) => (data?: unknown) => ({
       status: 200,

--- a/tests/server/tests/integration/sensitive-logging.test.ts
+++ b/tests/server/tests/integration/sensitive-logging.test.ts
@@ -1,0 +1,85 @@
+import { config } from '@rctf/config'
+import { challenges, createDatabase, type ChallengeData } from '@rctf/db'
+import { GoodFlag } from '@rctf/types'
+import { expect, test } from 'bun:test'
+import { eq } from 'drizzle-orm'
+import type { PinoLogger } from 'hono-pino'
+import { getFlagsForTeam } from '../../../../apps/api/src/providers/flags'
+import { submitFlag } from '../../../../apps/api/src/services/challenges'
+import { createRedis } from '../../../../apps/api/src/util/redis'
+import { generateRealTestUser } from '../../util'
+
+const getDb = () => createDatabase(config.database.sql).db
+
+test('does not include submitted flags in successful or cheated logs', async () => {
+  const db = getDb()
+  const redis = await createRedis()
+  const owner = await generateRealTestUser()
+  const submitter = await generateRealTestUser()
+  const challengeId = crypto.randomUUID()
+  const flagEntry = {
+    provider: 'flags/dynamic',
+    config: { base: 'rctf{abcdefghijklmnopqrstuvwxyz}', mode: 'auto' },
+  }
+  const challengeData: ChallengeData = {
+    name: 'Sensitive logging test',
+    description: '',
+    category: 'misc',
+    author: 'test',
+    files: [],
+    flags: [flagEntry],
+    tiebreakEligible: true,
+    points: { min: 100, max: 500 },
+  }
+  await db.insert(challenges).values({ id: challengeId, data: challengeData })
+
+  const captured: Array<{ level: string; args: unknown[] }> = []
+  const capture =
+    (level: string) =>
+    (...args: unknown[]) => {
+      captured.push({ level, args })
+    }
+  const logger = {
+    info: capture('info'),
+    warn: capture('warn'),
+    error: capture('error'),
+  } as unknown as PinoLogger
+  const responses = new Proxy(Object.create(null), {
+    get: (_target, property) => (data?: unknown) => ({
+      status: 200,
+      body: { kind: property, data },
+      definition: {},
+    }),
+  }) as Parameters<typeof submitFlag>[0]
+
+  try {
+    const [minted] = await getFlagsForTeam([flagEntry], {
+      db,
+      teamId: owner.user.id,
+      challengeId,
+    })
+    const secretFlag = minted!.flag
+
+    const ownerResult = await submitFlag(responses, db, redis, logger, {
+      userId: owner.user.id,
+      challengeId,
+      flag: secretFlag,
+      submissionIp: '127.0.0.1',
+    })
+    const cheatedResult = await submitFlag(responses, db, redis, logger, {
+      userId: submitter.user.id,
+      challengeId,
+      flag: secretFlag,
+      submissionIp: '127.0.0.1',
+    })
+
+    expect(ownerResult.body.kind).toBe(GoodFlag.kind)
+    expect(cheatedResult.body.kind).toBe(GoodFlag.kind)
+    expect(captured.some(entry => entry.level === 'warn')).toBe(true)
+    expect(JSON.stringify(captured)).not.toContain(secretFlag)
+  } finally {
+    await owner.cleanup()
+    await submitter.cleanup()
+    await db.delete(challenges).where(eq(challenges.id, challengeId))
+  }
+})

--- a/tests/server/tests/unit/logger.test.ts
+++ b/tests/server/tests/unit/logger.test.ts
@@ -1,0 +1,44 @@
+import { Writable } from 'node:stream'
+import { DrizzleQueryError } from 'drizzle-orm'
+import { expect, test } from 'bun:test'
+import { createApiLogger } from '../../../../apps/api/src/lib/logger'
+
+test('redacts query parameters and sensitive fields from serialized logs', async () => {
+  let output = ''
+  const destination = new Writable({
+    write(chunk, _encoding, callback) {
+      output += chunk.toString()
+      callback()
+    },
+  })
+  const logger = createApiLogger(destination, 'info')
+  const secret = 'flag{database-error-secret}'
+  const cause = Object.assign(new Error(`duplicate value ${secret}`), {
+    code: '23505',
+    constraint_name: 'submissions_pkey',
+  })
+  const error = new DrizzleQueryError(
+    'insert into submissions (details) values ($1)',
+    [secret],
+    cause
+  )
+
+  logger.error({ err: error }, 'query failed')
+  logger.info(
+    {
+      input: secret,
+      inputs: secret,
+      submittedFlag: secret,
+      details: { submittedFlag: secret },
+    },
+    'sensitive fields'
+  )
+  await new Promise<void>(resolve => destination.end(resolve))
+
+  expect(output).toContain('Database query failed')
+  expect(output).toContain('DrizzleQueryError')
+  expect(output).toContain('23505')
+  expect(output).toContain('submissions_pkey')
+  expect(output).not.toContain('insert into submissions')
+  expect(output).not.toContain(secret)
+})

--- a/tests/server/tests/unit/logger.test.ts
+++ b/tests/server/tests/unit/logger.test.ts
@@ -24,6 +24,12 @@ test('redacts query parameters and sensitive fields from serialized logs', async
   )
 
   logger.error({ err: error }, 'query failed')
+  logger.error(
+    {
+      error: new Error(`wrapped query failure ${secret}`, { cause: error }),
+    },
+    'wrapped query failed'
+  )
   logger.info(
     {
       input: secret,

--- a/tests/server/tests/unit/logger.test.ts
+++ b/tests/server/tests/unit/logger.test.ts
@@ -1,16 +1,10 @@
-import { Writable } from 'node:stream'
 import { DrizzleQueryError } from 'drizzle-orm'
 import { expect, test } from 'bun:test'
 import { createApiLogger } from '../../../../apps/api/src/lib/logger'
+import { collectStream } from '../../../util'
 
 test('redacts query parameters and sensitive fields from serialized logs', async () => {
-  let output = ''
-  const destination = new Writable({
-    write(chunk, _encoding, callback) {
-      output += chunk.toString()
-      callback()
-    },
-  })
+  const { destination, read } = collectStream()
   const logger = createApiLogger(destination, 'info')
   const secret = 'flag{database-error-secret}'
   const cause = Object.assign(new Error(`duplicate value ${secret}`), {
@@ -39,7 +33,7 @@ test('redacts query parameters and sensitive fields from serialized logs', async
     },
     'sensitive fields'
   )
-  await new Promise<void>(resolve => destination.end(resolve))
+  const output = await read()
 
   expect(output).toContain('Database query failed')
   expect(output).toContain('DrizzleQueryError')

--- a/tests/server/tests/unit/logger.test.ts
+++ b/tests/server/tests/unit/logger.test.ts
@@ -35,10 +35,9 @@ test('redacts query parameters and sensitive fields from serialized logs', async
   )
   const output = await read()
 
-  expect(output).toContain('Database query failed')
+  expect(output).toContain('Failed query: insert into submissions')
   expect(output).toContain('DrizzleQueryError')
   expect(output).toContain('23505')
   expect(output).toContain('submissions_pkey')
-  expect(output).not.toContain('insert into submissions')
   expect(output).not.toContain(secret)
 })

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,0 +1,16 @@
+import { Writable } from 'node:stream'
+
+export const collectStream = () => {
+  let output = ''
+  const destination = new Writable({
+    write(chunk, _encoding, callback) {
+      output += chunk.toString()
+      callback()
+    },
+  })
+  const read = async (): Promise<string> => {
+    await new Promise<void>(resolve => destination.end(resolve))
+    return output
+  }
+  return { destination, read }
+}


### PR DESCRIPTION
### tl;dr - asked codex/fable to do a review of this codebase and find some issues that have some prior precedent or discussion, and thought this would be a good one to knock out: preventing flags and other sensitive data from being logged.

ai slop summary below

## Summary

- stop successful and cheated submissions from logging plaintext flags
- restrict admin-bot job logs to non-sensitive identifiers
- redact common flag and participant-input fields across API and admin-bot loggers
- sanitize `DrizzleQueryError` instances, including wrapped cause chains
- retain safe database diagnostics such as SQLSTATE, constraint, and stack locations
- avoid serializing participant-controlled admin-bot error messages
- add regression tests against real Pino output

## Context

This is a follow-up to #199, which redacted sensitive request headers.

Pino's structural redaction does not cover secrets embedded inside error messages or stack traces. Drizzle query errors include bound parameters in their message, query, and params fields, which could expose submitted flags or admin-bot inputs during database failures.

This change extends the existing logging protections to application-level submission data and error paths. Sensitive values are removed at direct logging sites, with logger-level redaction and sanitized database-error serialization as defense in depth.

Submission audit records remain unchanged; this only affects operational logs.

## Testing

- `bun run test:server`
- `bun run test:admin-bot`
- `bun run test:admin-bot:e2e`
- `bun run build:api`
- `bun run --filter '@rctf/admin-bot' build`
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`