### PR TITLE
feat: implement custom pages

### DIFF
--- a/apps/api/src/routes/v2/integrations/routes/get-client-config.ts
+++ b/apps/api/src/routes/v2/integrations/routes/get-client-config.ts
@@ -29,6 +29,7 @@ integrationsGroup.route(GetClientConfigRouteV2, async ({ res, ctx }) => {
   const resolved = await getResolvedSettings(ctx.var.db, ctx.var.redis)
   return res.goodClientConfigV2({
     ...resolved,
+    customPages: config.customPages,
     flagFormatPlaceholder: config.flagFormatPlaceholder,
     divisions: config.divisions,
     defaultDivision: config.defaultDivision ?? null,

--- a/apps/docs/src/content/docs/configuration.md
+++ b/apps/docs/src/content/docs/configuration.md
@@ -386,6 +386,7 @@ customPages:
 
       Do not attack the competition infrastructure.
     showInNavigation: true
+    hideTitle: false
 sponsors:
   - name: Sponsor Name
     iconLight: https://example.com/sponsor-light.png
@@ -404,7 +405,7 @@ flagFormatPlaceholder: 'flag{[\x20-\x7e]+}'
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `<red>homeContent</red>` | `string{:ts}` | `"Home content. Markdown supported."{:ts}` | Home page content (Markdown) |
-| `<red>customPages</red>` | `array{:ts}` | `[]{:json}` | Public Markdown pages (`<red>slug</red>`, `<red>title</red>`, `<red>content</red>`, `<red>icon</red>`, `<red>showInNavigation</red>`) served at `<green>/pages/&lt;slug&gt;</green>`. Icons: `<green>file</green>`, `<green>info</green>`, `<green>question</green>`, `<green>warning</green>`, `<green>gavel</green>`, `<green>globe</green>`, `<green>flag</green>`, `<green>trophy</green>`, `<green>users</green>`, `<green>clock</green>`, `<green>key</green>`, or `<green>puzzle</green>`. |
+| `<red>customPages</red>` | `array{:ts}` | `[]{:json}` | Public Markdown pages (`<red>slug</red>`, `<red>title</red>`, `<red>content</red>`, `<red>icon</red>`, `<red>showInNavigation</red>`, `<red>hideTitle</red>`) served at `<green>/pages/&lt;slug&gt;</green>`. Set `<red>hideTitle</red>` to `<green>true</green>` to omit the visible title while retaining it for navigation and the browser tab. Icons: `<green>file</green>`, `<green>info</green>`, `<green>question</green>`, `<green>warning</green>`, `<green>gavel</green>`, `<green>globe</green>`, `<green>flag</green>`, `<green>trophy</green>`, `<green>users</green>`, `<green>clock</green>`, `<green>key</green>`, or `<green>puzzle</green>`. |
 | `<red>sponsors</red>` | `array{:ts}` | `[]{:json}` | List of sponsors (`<red>name</red>`, `<red>iconLight</red>`, `<red>iconDark</red>`, `<red>description</red>`, `<red>url</red>`). When only one mode's icon is set, the home page renders it color-inverted in the other mode; legacy `<red>icon</red>` is accepted as the light-mode icon |
 | `<red>meta.description</red>` | `string{:ts}` | `"rCTF event description"{:ts}` | HTML meta description |
 | `<red>meta.imageUrl</red>` | `string{:ts}` | `""{:ts}` | HTML meta image URL |

--- a/apps/docs/src/content/docs/configuration.md
+++ b/apps/docs/src/content/docs/configuration.md
@@ -377,6 +377,15 @@ homeContent: |
   Welcome to My CTF!
 
   **Markdown** is supported.
+customPages:
+  - slug: rules
+    title: Rules
+    icon: info
+    content: |
+      # Competition rules
+
+      Do not attack the competition infrastructure.
+    showInNavigation: true
 sponsors:
   - name: Sponsor Name
     iconLight: https://example.com/sponsor-light.png
@@ -395,6 +404,7 @@ flagFormatPlaceholder: 'flag{[\x20-\x7e]+}'
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `<red>homeContent</red>` | `string{:ts}` | `"Home content. Markdown supported."{:ts}` | Home page content (Markdown) |
+| `<red>customPages</red>` | `array{:ts}` | `[]{:json}` | Public Markdown pages (`<red>slug</red>`, `<red>title</red>`, `<red>content</red>`, `<red>icon</red>`, `<red>showInNavigation</red>`) served at `<green>/pages/&lt;slug&gt;</green>`. Icons: `<green>file</green>`, `<green>info</green>`, `<green>question</green>`, `<green>warning</green>`, `<green>gavel</green>`, `<green>globe</green>`, `<green>flag</green>`, `<green>trophy</green>`, `<green>users</green>`, `<green>clock</green>`, `<green>key</green>`, or `<green>puzzle</green>`. |
 | `<red>sponsors</red>` | `array{:ts}` | `[]{:json}` | List of sponsors (`<red>name</red>`, `<red>iconLight</red>`, `<red>iconDark</red>`, `<red>description</red>`, `<red>url</red>`). When only one mode's icon is set, the home page renders it color-inverted in the other mode; legacy `<red>icon</red>` is accepted as the light-mode icon |
 | `<red>meta.description</red>` | `string{:ts}` | `"rCTF event description"{:ts}` | HTML meta description |
 | `<red>meta.imageUrl</red>` | `string{:ts}` | `""{:ts}` | HTML meta image URL |

--- a/apps/web/src/lib/components/navigation-mobile.svelte
+++ b/apps/web/src/lib/components/navigation-mobile.svelte
@@ -25,6 +25,7 @@
   import Dialog from '$lib/ui/dialog.svelte'
   import Tooltip from '$lib/ui/tooltip.svelte'
   import { copyLoginUrl, logout } from '$lib/utils/auth'
+  import { getCustomPageIcon } from '$lib/utils/custom-page-icons'
   import {
     ADMIN_PANEL_PERMISSIONS,
     hasAnyPermission,
@@ -79,6 +80,13 @@
         icon: IconGlobeHemisphereWest,
         show: true,
       },
+      ...(clientConfig?.customPages ?? []).map(customPage => ({
+        href: `/pages/${customPage.slug}`,
+        activePath: `/pages/${customPage.slug}`,
+        label: customPage.title,
+        icon: getCustomPageIcon(customPage.icon),
+        show: customPage.showInNavigation,
+      })),
       {
         href: '/profile',
         activePath: '/profile',

--- a/apps/web/src/lib/components/navigation.svelte
+++ b/apps/web/src/lib/components/navigation.svelte
@@ -27,6 +27,7 @@
   import Tooltip from '$lib/ui/tooltip.svelte'
   import { copyLoginUrl, logout } from '$lib/utils/auth'
   import { countryCodeToFlagFilename } from '$lib/utils/flags'
+  import { getCustomPageIcon } from '$lib/utils/custom-page-icons'
   import {
     ADMIN_PANEL_PERMISSIONS,
     hasAnyPermission,
@@ -165,6 +166,21 @@
           />
         {/snippet}
       </Tooltip>
+      {#each clientConfig?.customPages.filter(page => page.showInNavigation) ?? [] as customPage (customPage.slug)}
+        {@const Icon = getCustomPageIcon(customPage.icon)}
+        <Tooltip label={customPage.title}>
+          {#snippet children({ props })}
+            <NavigationButton
+              {...props}
+              data-roving
+              href="/pages/{customPage.slug}"
+              activePath="/pages/{customPage.slug}"
+              label={customPage.title}
+              icon={Icon}
+            />
+          {/snippet}
+        </Tooltip>
+      {/each}
       {#if isAdmin}
         <Tooltip label="Admin">
           {#snippet children({ props: tooltipProps })}

--- a/apps/web/src/lib/utils/custom-page-icons.ts
+++ b/apps/web/src/lib/utils/custom-page-icons.ts
@@ -1,0 +1,34 @@
+import type { ClientConfig } from '@rctf/types'
+import {
+  IconClock,
+  IconFile,
+  IconFlagBannerFold,
+  IconGavel,
+  IconGlobeHemisphereWest,
+  IconInfo,
+  IconKey,
+  IconPuzzlePiece,
+  IconQuestion,
+  IconTrophy,
+  IconUsersThree,
+  IconWarning,
+} from '$lib/icons'
+
+type CustomPageIcon = ClientConfig['customPages'][number]['icon']
+
+const customPageIcons = {
+  file: IconFile,
+  info: IconInfo,
+  question: IconQuestion,
+  warning: IconWarning,
+  gavel: IconGavel,
+  globe: IconGlobeHemisphereWest,
+  flag: IconFlagBannerFold,
+  trophy: IconTrophy,
+  users: IconUsersThree,
+  clock: IconClock,
+  key: IconKey,
+  puzzle: IconPuzzlePiece,
+} satisfies Record<CustomPageIcon, typeof IconFile>
+
+export const getCustomPageIcon = (icon: CustomPageIcon) => customPageIcons[icon]

--- a/apps/web/src/routes/pages/[slug]/+page.svelte
+++ b/apps/web/src/routes/pages/[slug]/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import Markdown from '$lib/components/markdown.svelte'
+  import Card from '$lib/ui/card.svelte'
+  import type { PageProps } from './$types'
+
+  const { data }: PageProps = $props()
+</script>
+
+<svelte:head>
+  <title>{data.customPage.title} · {data.clientConfig.ctfName}</title>
+</svelte:head>
+
+<custom-page>
+  <Card title={data.customPage.title}>
+    <Markdown content={data.customPage.content} />
+  </Card>
+</custom-page>
+
+<style>
+  custom-page {
+    display: block;
+    inline-size: 100%;
+    max-inline-size: calc(var(--measure) + 4.5rem);
+    margin-inline: auto;
+    padding: var(--space-s) 2.25rem;
+  }
+</style>

--- a/apps/web/src/routes/pages/[slug]/+page.svelte
+++ b/apps/web/src/routes/pages/[slug]/+page.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <custom-page>
-  <Card title={data.customPage.title}>
+  <Card title={data.customPage.hideTitle ? undefined : data.customPage.title}>
     <Markdown content={data.customPage.content} />
   </Card>
 </custom-page>

--- a/apps/web/src/routes/pages/[slug]/+page.ts
+++ b/apps/web/src/routes/pages/[slug]/+page.ts
@@ -1,0 +1,13 @@
+import { error } from '@sveltejs/kit'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ params, parent }) => {
+  const { clientConfig } = await parent()
+  const customPage = clientConfig.customPages.find(
+    page => page.slug === params.slug
+  )
+
+  if (!customPage) error(404, 'Page not found')
+
+  return { customPage }
+}

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,4 +1,5 @@
 import {
+  CustomPageIconSchema,
   normalizeSponsorIcons,
   NumericString,
   ProtectedAction,
@@ -23,6 +24,16 @@ export const SponsorSchema = z.pipe(
   }),
   z.transform(normalizeSponsorIcons)
 )
+
+export const CustomPageSchema = z.object({
+  slug: z
+    .string()
+    .check(z.regex(/^[a-z0-9-]+$/), z.minLength(1), z.maxLength(64)),
+  title: z.string().check(z.minLength(1)),
+  content: z.string(),
+  icon: z._default(CustomPageIconSchema, 'file'),
+  showInNavigation: z._default(z.boolean(), true),
+})
 
 // Division access control: matches field `match` against `value`, applies to listed divisions
 export const ACLSchema = z.object({
@@ -138,6 +149,7 @@ export const ServerConfigSchema = z.object({
 
   // UI
   homeContent: z._default(z.string(), 'Home content. Markdown supported.'),
+  customPages: z._default(z.array(CustomPageSchema), []),
   sponsors: z._default(z.array(SponsorSchema), []),
   meta: z.prefault(
     z.object({
@@ -236,5 +248,6 @@ export const ServerConfigSchema = z.object({
 })
 export type ProviderConfig = z.infer<typeof ProviderConfigSchema>
 export type Sponsor = z.infer<typeof SponsorSchema>
+export type CustomPage = z.infer<typeof CustomPageSchema>
 export type ACL = z.infer<typeof ACLSchema>
 export type ServerConfig = z.infer<typeof ServerConfigSchema>

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -33,6 +33,7 @@ export const CustomPageSchema = z.object({
   content: z.string(),
   icon: z._default(CustomPageIconSchema, 'file'),
   showInNavigation: z._default(z.boolean(), true),
+  hideTitle: z._default(z.boolean(), false),
 })
 
 // Division access control: matches field `match` against `value`, applies to listed divisions

--- a/packages/types/src/responses/good-client-config-v2.ts
+++ b/packages/types/src/responses/good-client-config-v2.ts
@@ -37,6 +37,9 @@ export const GoodClientConfigV2 = response('goodClientConfigV2', {
           showInNavigation: example(z.boolean(), true).check(
             z.describe('Whether to link the page from the main navigation.')
           ),
+          hideTitle: example(z.boolean(), false).check(
+            z.describe('Whether to hide the page title above the content.')
+          ),
         })
       )
       .check(z.describe('Custom public Markdown pages.')),

--- a/packages/types/src/responses/good-client-config-v2.ts
+++ b/packages/types/src/responses/good-client-config-v2.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod/mini'
 import { ProtectedAction } from '../enums'
 import { response } from '../internal'
-import { NumericString, SponsorSchemaV2 } from '../util'
+import { CustomPageIconSchema, NumericString, SponsorSchemaV2 } from '../util'
 import { example } from '../util/example'
 
 export const GoodClientConfigV2 = response('goodClientConfigV2', {
@@ -19,6 +19,27 @@ export const GoodClientConfigV2 = response('goodClientConfigV2', {
     homeContent: example(z.string(), '# Welcome').check(
       z.describe('Markdown content shown on the home page.')
     ),
+    customPages: z
+      .array(
+        z.object({
+          slug: example(z.string(), 'rules').check(
+            z.describe('URL-safe page identifier.')
+          ),
+          title: example(z.string(), 'Rules').check(
+            z.describe('Page and navigation title.')
+          ),
+          content: example(z.string(), '# Competition rules').check(
+            z.describe('Markdown content shown on the page.')
+          ),
+          icon: example(CustomPageIconSchema, 'file').check(
+            z.describe('Icon displayed in the main navigation.')
+          ),
+          showInNavigation: example(z.boolean(), true).check(
+            z.describe('Whether to link the page from the main navigation.')
+          ),
+        })
+      )
+      .check(z.describe('Custom public Markdown pages.')),
     sponsors: z.array(SponsorSchemaV2),
     flagFormatPlaceholder: example(z.string(), 'rctf{...}').check(
       z.describe('Placeholder shown in the flag submission box.')

--- a/packages/types/src/util/schemas.ts
+++ b/packages/types/src/util/schemas.ts
@@ -1,6 +1,21 @@
 import { z } from 'zod/mini'
 import { example } from './example'
 
+export const CustomPageIconSchema = z.enum([
+  'file',
+  'info',
+  'question',
+  'warning',
+  'gavel',
+  'globe',
+  'flag',
+  'trophy',
+  'users',
+  'clock',
+  'key',
+  'puzzle',
+])
+
 export enum ExposeKind {
   TCP = 'tcp',
   TCP_SSL = 'tcp-ssl',

--- a/tests/server/tests/unit/custom-pages.test.ts
+++ b/tests/server/tests/unit/custom-pages.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test'
+import { CustomPageSchema } from '../../../../packages/config/src/types'
+
+const customPage = {
+  slug: 'rules',
+  title: 'Rules',
+  content: '# Competition rules',
+}
+
+describe('custom pages', () => {
+  test('shows the page title by default', () => {
+    expect(CustomPageSchema.parse(customPage).hideTitle).toBe(false)
+  })
+
+  test('allows the page title to be hidden', () => {
+    expect(
+      CustomPageSchema.parse({ ...customPage, hideTitle: true }).hideTitle
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
This PR adds a `customPages` field for custom pages. I asked GPT-5.6 to create an implementation. Yet I am not sure how to handle ordering pages. For example, rules should come after home page in the navigation bar.

Implementation screenshot:
<img width="1148" height="616" alt="Screenshot 2026-08-03 at 18 15 14" src="https://github.com/user-attachments/assets/ab8f7a77-1400-475a-afb2-68079b92fa2b" />
<img width="488" height="632" alt="Screenshot 2026-08-03 at 18 15 48" src="https://github.com/user-attachments/assets/c8abb2dc-8193-4c25-82d3-866d6127a157" />
