### PR TITLE
chore: update team name link to direct to admin profile in submissions list

### DIFF
--- a/apps/web/src/routes/admin/submissions/table/submissions-row.svelte
+++ b/apps/web/src/routes/admin/submissions/table/submissions-row.svelte
@@ -82,7 +82,7 @@
       <Avatar src={submission.userAvatarUrl} name={submission.userName} />
     </avatar-slot>
     <a
-      href="/profile/{submission.userId}"
+      href="/admin/profile/{submission.userId}"
       onclick={event => event.stopPropagation()}
     >
       {submission.userName}


### PR DESCRIPTION
Team name in https://demo.rctf.osec.io/admin/submissions now directly links to admin profile management. Related to #197 