### PR TITLE
chore(admin-bot): prevent firefox from launching at windows startup

### DIFF
--- a/apps/admin-bot/src/core/const.ts
+++ b/apps/admin-bot/src/core/const.ts
@@ -27,4 +27,5 @@ export const defaultFirefoxPreferences: Record<string, unknown> = {
   'javascript.options.ion': false,
   'javascript.options.baselinejit': false,
   'javascript.options.wasm_baselinejit': false,
+  'browser.startup.windowsLaunchOnLogin.defaultEnabled': false,
 }


### PR DESCRIPTION
For losers who use windows(me), prevent adminbot firefox instances from adding themselves to startup so I don't need to close 6 different firefox tabs every time I restart windows