### PR TITLE
feat(k8s-operator): allow overriding dns policy

### DIFF
--- a/apps/k8s-operator/internal/controller/challengeinstance_controller.go
+++ b/apps/k8s-operator/internal/controller/challengeinstance_controller.go
@@ -482,7 +482,9 @@ func (r *ChallengeInstanceReconciler) deployResources(ctx context.Context, insta
 			if podSpec.EnableServiceLinks == nil {
 				podSpec.EnableServiceLinks = ptr.To(false)
 			}
-			podSpec.DNSPolicy = corev1.DNSNone
+			if podSpec.DNSPolicy == "" {
+				podSpec.DNSPolicy = corev1.DNSNone
+			}
 			if podSpec.DNSConfig == nil {
 				podSpec.DNSConfig = &corev1.PodDNSConfig{
 					Nameservers: []string{"1.1.1.1", "1.0.0.1"},


### PR DESCRIPTION
Changes in https://github.com/otter-sec/rctf/pull/209 enforced "None" DNS policy. In certain situations, challenge instances might want to use the in-cluster DNS to resolve certain in-cluster services.