### PR TITLE
fix(frontend): fix challenge sort weight

### DIFF
--- a/apps/api/src/services/challenges.ts
+++ b/apps/api/src/services/challenges.ts
@@ -183,7 +183,7 @@ export const isChallengePublic = (challenge: Challenge): boolean => {
 }
 
 const challengeDefaultOrder = [
-  sql`((${challenges.data} ->> 'sortWeight')::int) NULLS LAST`,
+  desc(sql`COALESCE((${challenges.data} ->> 'sortWeight')::int, 0)`),
   desc(challenges.id),
 ] as const
 

--- a/apps/web/src/routes/admin/challenges/list/list-logic.ts
+++ b/apps/web/src/routes/admin/challenges/list/list-logic.ts
@@ -22,7 +22,11 @@ export function groupChallenges(challenges: AdminChallenge[]): CategoryGroup[] {
 
   const result = [...groups.entries()].map(([category, list]) => ({
     category,
-    challenges: [...list].sort((a, b) => a.name.localeCompare(b.name)),
+    challenges: [...list].sort(
+      (a, b) =>
+        (b.sortWeight ?? 0) - (a.sortWeight ?? 0) ||
+        a.name.localeCompare(b.name)
+    ),
   }))
   result.sort((a, b) => compareCategories(a.category, b.category))
   return result

--- a/apps/web/src/routes/challenges/list/list-logic.ts
+++ b/apps/web/src/routes/challenges/list/list-logic.ts
@@ -113,6 +113,10 @@ function sortWithinCategory(challenges: Challenge[]): Challenge[] {
     if (bySolves !== 0) {
       return bySolves
     }
+    const byWeight = (b.sortWeight ?? 0) - (a.sortWeight ?? 0)
+    if (byWeight !== 0) {
+      return byWeight
+    }
     return a.name.localeCompare(b.name)
   })
 }

--- a/apps/web/tests/routes/admin/challenges/list/list-logic.test.ts
+++ b/apps/web/tests/routes/admin/challenges/list/list-logic.test.ts
@@ -59,6 +59,30 @@ describe('groupChallenges', () => {
     expect(groups[0]?.challenges.map(c => c.id)).toEqual(['a', 'b'])
   })
 
+  test('sorts by sortWeight descending, treating unset weight as 0', () => {
+    const challenges = [
+      makeChallenge({ id: '1', category: 'web', name: 'middle' }),
+      makeChallenge({
+        id: '2',
+        category: 'web',
+        name: 'first',
+        sortWeight: 10,
+      }),
+      makeChallenge({
+        id: '3',
+        category: 'web',
+        name: 'last',
+        sortWeight: -1,
+      }),
+    ]
+    const groups = groupChallenges(challenges)
+    expect(groups[0]?.challenges.map(c => c.name)).toEqual([
+      'first',
+      'middle',
+      'last',
+    ])
+  })
+
   test('sorts challenges within a category by name', () => {
     const challenges = [
       makeChallenge({ id: '1', category: 'web', name: 'charlie' }),

--- a/apps/web/tests/routes/challenges/list/list-logic.test.ts
+++ b/apps/web/tests/routes/challenges/list/list-logic.test.ts
@@ -107,6 +107,66 @@ describe('groupChallenges', () => {
     ])
   })
 
+  test('breaks points/solves ties by sortWeight desc, unset weight as 0', () => {
+    const challenges = [
+      makeChallenge({ id: '1', category: 'web', name: 'middle' }),
+      makeChallenge({
+        id: '2',
+        category: 'web',
+        name: 'first',
+        sortWeight: 10,
+      }),
+      makeChallenge({
+        id: '3',
+        category: 'web',
+        name: 'last',
+        sortWeight: -1,
+      }),
+    ]
+    const groups = groupChallenges(challenges)
+    expect(groups[0]?.challenges.map(challenge => challenge.name)).toEqual([
+      'first',
+      'middle',
+      'last',
+    ])
+  })
+
+  test('sortWeight does not outrank solves', () => {
+    const challenges = [
+      makeChallenge({
+        id: '1',
+        category: 'web',
+        name: 'heavy',
+        solves: 1,
+        sortWeight: 100,
+      }),
+      makeChallenge({ id: '2', category: 'web', name: 'solved', solves: 9 }),
+    ]
+    const groups = groupChallenges(challenges)
+    expect(groups[0]?.challenges.map(challenge => challenge.name)).toEqual([
+      'solved',
+      'heavy',
+    ])
+  })
+
+  test('does not order by points, which is 0 for dynamic challenges', () => {
+    const challenges = [
+      makeChallenge({ id: '1', category: 'web', name: 'dynamic', points: 0 }),
+      makeChallenge({
+        id: '2',
+        category: 'web',
+        name: 'decay',
+        points: 500,
+        solves: 3,
+      }),
+    ]
+    const groups = groupChallenges(challenges)
+    expect(groups[0]?.challenges.map(challenge => challenge.name)).toEqual([
+      'decay',
+      'dynamic',
+    ])
+  })
+
   test('returns an empty array for no challenges', () => {
     expect(groupChallenges([])).toEqual([])
   })

--- a/packages/types/src/routes/v1/admin.ts
+++ b/packages/types/src/routes/v1/admin.ts
@@ -88,7 +88,7 @@ export const UpdateChallengeRoute = defineRoute({
             })
           )
         ),
-        sortWeight: example(z.optional(z.number()), 0).check(
+        sortWeight: example(z.optional(z.int32()), 0).check(
           z.describe('Manual ordering weight.')
         ),
       })

--- a/packages/types/src/routes/v2/admin.ts
+++ b/packages/types/src/routes/v2/admin.ts
@@ -421,7 +421,7 @@ export const UpdateChallengeRouteV2 = defineRoute({
           z.describe('Whether solves count toward tiebreak ordering.')
         ),
         files: z.optional(z.array(ChallengeFileSchemaV2)),
-        sortWeight: example(z.optional(z.number()), 0).check(
+        sortWeight: example(z.optional(z.int32()), 0).check(
           z.describe('Manual ordering weight.')
         ),
         tags: example(z.optional(z.array(z.string())), ['beginner']).check(


### PR DESCRIPTION
Currently, `sortWeight` is not being respected by the frontend.

in rCTF v1, the `sortWeight` defaults to 0 if not defined: https://github.com/redpwn/rctf/blob/debc13d43fb7c0e10c6ff49c747afd4882b1871d/client/src/routes/challs.js#L117-L128